### PR TITLE
Relax version constraint on open-ended dev gems

### DIFF
--- a/wabur.gemspec
+++ b/wabur.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'oj', '~> 3.3'
 
-  s.add_development_dependency 'rake', '~> 0'
-  s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'rake', '>= 0', '< 13.0'
+  s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
   s.add_development_dependency 'minitest', '~> 5'
   
 end


### PR DESCRIPTION
Marking a gem with `~> 0` locks its use to only within `0.x.x` series. See [AppVeyor Log L#11](https://ci.appveyor.com/project/ohler55/wabur/build/1.0.30/job/dxxykmmjd0yrq0c5#L11) for proof.

Instead remove `open-ended dependency` warning from Rubygems by using a verbose declaration: Use versions less than next major version.