### PR TITLE
Use Bundler to load the library for tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ task :test_all => [:clean] do
   exitcode = 0
   status = 0
 
-  cmds = "ruby test/impl_test.rb"
+  cmds = "bundle exec ruby test/impl_test.rb"
   puts "\n" + "#"*90
   puts cmds
   Bundler.with_clean_env do


### PR DESCRIPTION
With this patch, we can progress to avoid defining `$:` in test files.. 