### PR TITLE
Return key from older Fixnum class earlier

### DIFF
--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -375,14 +375,13 @@ module WAB
       end
 
       def key_to_int(key)
-        return key if key.is_a?(Integer)
+        return key if (key.is_a?(Integer) || WAB::Utils.pre_24_fixnum?(key))
 
         key = key.to_s if key.is_a?(Symbol)
         if key.is_a?(String)
           i = key.to_i
           return i if i.to_s == key
         end
-        return key if WAB::Utils.pre_24_fixnum?(key)
 
         raise StandardError.new("path key must be an integer for an Array.") unless i.to_s == key
       end


### PR DESCRIPTION
return both key of Ruby24 `Integer` class and Ruby 23- `Fixnum` class earlier