### PR TITLE
Remove duplicate assignments in `IO::Call`

### DIFF
--- a/lib/wab/io/call.rb
+++ b/lib/wab/io/call.rb
@@ -15,16 +15,10 @@ module WAB
       attr_accessor :giveup
       
       def initialize(handler, qrid, timeout=2.0)
-        @rid = nil
         @qrid = qrid
-        @result = nil
         @giveup = Time.now + timeout
         @handler = handler
-        if handler.nil?
-          @thread = Thread.current
-        else
-          @thread = nil
-        end
+        @thread = Thread.current if handler.nil?
       end
 
     end # Call


### PR DESCRIPTION
defining `attr_accessors` for an `instance_variable` already assigns the variable an initial value of `nil`