### PR TITLE
Raise unless arguments supplied to test runner

### DIFF
--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -19,6 +19,7 @@ require 'wab/io'
 # As an example:
 #    runner_test.rb -v localhost:6363
 #
+raise ArgumentError, "Host and port not supplied." if ARGV.empty?
 
 $host, $port = ARGV[-1].split(':')
 $port = $port.to_i


### PR DESCRIPTION
Since an empty `ARGV` cannot be split, `raise` beforehand.