### PR TITLE
Zombie killer

### DIFF
--- a/test/ioshell_test.rb
+++ b/test/ioshell_test.rb
@@ -279,6 +279,8 @@ class IoEngineTest < Minitest::Test
           raise e
         end
       }
+      to_w.puts(::WAB::Impl::Data.new({ api: -2 }, false).json)
+      to_w.flush
     end
   end
 


### PR DESCRIPTION
Explicitly cause threads to exit in the unit tests to avoid zombies.