### PR TITLE
Easier testing with a test helper

### DIFF
--- a/test/data_test.rb
+++ b/test/data_test.rb
@@ -1,15 +1,10 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << __dir__
-$: << File.join(File.dirname(File.expand_path(__dir__)), 'lib')
-
-require 'minitest'
-require 'minitest/autorun'
+require_relative 'helper'
 
 require 'wab'
 require 'wab/impl'
-
 
 class DataTest < Minitest::Test
 
@@ -21,6 +16,7 @@ class DataTest < Minitest::Test
     def initialize(x, y)
       @h = {x: x, y: y }
     end
+
     def to_h
       @h
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,7 @@
+# encoding: UTF-8
+
+$LOAD_PATH << __dir__
+$LOAD_PATH << File.expand_path('../lib', __dir__)
+
+require 'minitest'
+require 'minitest/autorun'

--- a/test/http.rb
+++ b/test/http.rb
@@ -1,12 +1,10 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << __dir__
-$: << File.join(File.dirname(File.expand_path(__dir__)), 'lib')
+require_relative 'helper'
 
 require 'wab'
 require 'wab/impl'
 require 'wab/impl/server'
 
 ::WAB::Impl::Server.new(nil, 6363, 'pages', 'v1/')
-

--- a/test/impl_test.rb
+++ b/test/impl_test.rb
@@ -1,11 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << __dir__
-
-require 'minitest'
-require 'minitest/autorun'
+require_relative 'helper'
 
 require 'wab/impl'
-
 require 'data_test'

--- a/test/ioshell_bench.rb
+++ b/test/ioshell_bench.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << __dir__
-$: << File.join(File.dirname(File.expand_path(__dir__)), 'lib')
+require_relative 'helper'
 
 require 'benchmark'
 

--- a/test/ioshell_test.rb
+++ b/test/ioshell_test.rb
@@ -1,16 +1,11 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << __dir__
-$: << File.join(File.dirname(File.expand_path(__dir__)), 'lib')
-
-require 'minitest'
-require 'minitest/autorun'
+require_relative 'helper'
 
 require 'wab/impl'
 require 'wab/io'
 require 'mirror_controller'
-
 
 class IoEngineTest < Minitest::Test
 

--- a/test/ioshell_test.rb
+++ b/test/ioshell_test.rb
@@ -278,7 +278,7 @@ class IoEngineTest < Minitest::Test
         begin
           assert_equal(pair[1], reply)
         rescue Exception => e
-          puts
+          puts ''
           puts bt
           raise e
         end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -1,14 +1,11 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << __dir__
-$: << File.join(File.dirname(File.expand_path(__dir__)), 'lib')
+require_relative 'helper'
 
-require 'minitest'
-require 'minitest/autorun'
 require 'net/http'
-
 require 'oj'
+
 require 'wab/impl'
 require 'wab/io'
 

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1,12 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
-$: << File.dirname(__FILE__)
-$: << File.join(File.dirname(File.dirname(File.expand_path(__FILE__))), 'lib')
-
-require 'minitest'
-require 'minitest/autorun'
+require_relative 'helper'
 
 require 'impl_test'
-
 require 'ioshell_test'


### PR DESCRIPTION
With this you no longer need to manipulate load paths or / and explicitly `require` the `minitest` library with each new test file at the root of `./test`, Simply add `require_relative 'helper'` and you're set.

Ideally we can `require` all the libraries we need, in the helper. But since you like to run a test-file as a standalone Ruby script locally, leaving them as is..