### PR TITLE
attr_readers and aliases

### DIFF
--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -34,7 +34,7 @@ module WAB
 
       # Returns the instance converted to native Ruby values such as a Hash,
       # Array, etc.
-      alias :native :root
+      alias native root
 
       # Gets the Data element or value identified by the path where the path
       # elements are separated by the '.' character. The path can also be a

--- a/lib/wab/shell.rb
+++ b/lib/wab/shell.rb
@@ -17,6 +17,9 @@ module WAB
   # the methods remain the same.
   class Shell
 
+    # Returns the path where a data type is located. The default is 'kind'.
+    attr_reader :type_key
+
     # Sets up the shell with a type_key and path position.
     #
     # type_key:: key for the type associated with a record
@@ -29,11 +32,6 @@ module WAB
 
     # Starts the shell.
     def start()
-    end
-
-    # Returns the path where a data type is located. The default is 'kind'.
-    def type_key()
-      @type_key
     end
 
     # Register a controller for a named type.

--- a/lib/wab/uuid.rb
+++ b/lib/wab/uuid.rb
@@ -15,9 +15,7 @@ module WAB
     end
 
     # Returns the string representation of the UUID.
-    def to_s
-      @id
-    end
+    alias :to_s :id
 
     def ==(other)
       other.is_a?(self.class) && @id == other.id

--- a/lib/wab/uuid.rb
+++ b/lib/wab/uuid.rb
@@ -15,7 +15,7 @@ module WAB
     end
 
     # Returns the string representation of the UUID.
-    alias :to_s :id
+    alias to_s id
 
     def ==(other)
       other.is_a?(self.class) && @id == other.id


### PR DESCRIPTION
Ruby stdlib uses `alias` with non-symbol parameters though symbol parameters work too..