### PR TITLE
Organize expr files into a directory

### DIFF
--- a/lib/wab/impl.rb
+++ b/lib/wab/impl.rb
@@ -8,4 +8,26 @@ module WAB
 end
 
 require 'wab/impl/data'
+require 'wab/impl/expr'
+require 'wab/impl/path_expr'
+require 'wab/impl/bool_expr'
 require 'wab/impl/shell'
+
+# Require the concrete Expr subclasses so a mapping table can be created for
+# the parser.
+
+require 'wab/impl/exprs/between'
+require 'wab/impl/exprs/eq'
+require 'wab/impl/exprs/gt'
+require 'wab/impl/exprs/gte'
+require 'wab/impl/exprs/has'
+require 'wab/impl/exprs/in'
+require 'wab/impl/exprs/lt'
+require 'wab/impl/exprs/lte'
+require 'wab/impl/exprs/regex'
+
+require 'wab/impl/exprs/and'
+require 'wab/impl/exprs/or'
+require 'wab/impl/exprs/not'
+
+require 'wab/impl/expr_parser'

--- a/lib/wab/impl/bool_expr.rb
+++ b/lib/wab/impl/bool_expr.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/expr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/expr.rb
+++ b/lib/wab/impl/expr.rb
@@ -1,6 +1,4 @@
 
-require 'wab'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/expr_parser.rb
+++ b/lib/wab/impl/expr_parser.rb
@@ -1,25 +1,7 @@
 
-require 'wab'
-
-# Require the concrete Expr classes so a mapping table can be created for the
-# parser.
-require 'wab/impl/between'
-require 'wab/impl/eq'
-require 'wab/impl/gt'
-require 'wab/impl/gte'
-require 'wab/impl/has'
-require 'wab/impl/in'
-require 'wab/impl/lt'
-require 'wab/impl/lte'
-require 'wab/impl/regex'
-
-require 'wab/impl/and'
-require 'wab/impl/or'
-require 'wab/impl/not'
-
 module WAB
   module Impl
-    class Expr
+    class ExprParser
       @xmap = {
         between: Between,
         eq: Eq,
@@ -63,6 +45,6 @@ module WAB
         xclass.new(*args)
       end
 
-    end # Expr
+    end # ExprParser
   end # Impl
 end # WAB

--- a/lib/wab/impl/exprs/and.rb
+++ b/lib/wab/impl/exprs/and.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/boolexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/between.rb
+++ b/lib/wab/impl/exprs/between.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/eq.rb
+++ b/lib/wab/impl/exprs/eq.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/gt.rb
+++ b/lib/wab/impl/exprs/gt.rb
@@ -1,14 +1,12 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 
-    # Matches a node that has a value less than or equal to the provided
-    # value. If a integer or float is provided then both integer and floats
-    # are checked. If the value provided is a time then only time nodes are
+    # Matches a node that has a value greater than the provided value. If a
+    # integer or float is provided then both integer and floats are
+    # checked. If the value provided is a time then only time nodes are
     # checked. Any other type results in an error.
-    class Lte < PathExpr
+    class Gt < PathExpr
 
       # Creates a new instance with the provided parameters.
       #
@@ -20,13 +18,13 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) <= @value
+        data.get(@path) > @value
       end
 
       def native()
-        ['LTE', @path, @value]
+        ['GT', @path, @value]
       end
 
-    end # Lte
+    end # Gt
   end # Impl
 end # WAB

--- a/lib/wab/impl/exprs/gte.rb
+++ b/lib/wab/impl/exprs/gte.rb
@@ -1,14 +1,12 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 
-    # Matches a node that has a value greater than the provided value. If a
-    # integer or float is provided then both integer and floats are
-    # checked. If the value provided is a time then only time nodes are
+    # Matches a node that has a value greater than or equals to the provided
+    # value. If a integer or float is provided then both integer and floats
+    # are checked. If the value provided is a time then only time nodes are
     # checked. Any other type results in an error.
-    class Gt < PathExpr
+    class Gte < PathExpr
 
       # Creates a new instance with the provided parameters.
       #
@@ -20,13 +18,13 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) > @value
+        data.get(@path) >= @value
       end
 
       def native()
-        ['GT', @path, @value]
+        ['GTE', @path, @value]
       end
 
-    end # Gt
+    end # Gte
   end # Impl
 end # WAB

--- a/lib/wab/impl/exprs/has.rb
+++ b/lib/wab/impl/exprs/has.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/in.rb
+++ b/lib/wab/impl/exprs/in.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/lt.rb
+++ b/lib/wab/impl/exprs/lt.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/lte.rb
+++ b/lib/wab/impl/exprs/lte.rb
@@ -1,14 +1,12 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 
-    # Matches a node that has a value greater than or equals to the provided
+    # Matches a node that has a value less than or equal to the provided
     # value. If a integer or float is provided then both integer and floats
     # are checked. If the value provided is a time then only time nodes are
     # checked. Any other type results in an error.
-    class Gte < PathExpr
+    class Lte < PathExpr
 
       # Creates a new instance with the provided parameters.
       #
@@ -20,13 +18,13 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) >= @value
+        data.get(@path) <= @value
       end
 
       def native()
-        ['GTE', @path, @value]
+        ['LTE', @path, @value]
       end
 
-    end # Gte
+    end # Lte
   end # Impl
 end # WAB

--- a/lib/wab/impl/exprs/not.rb
+++ b/lib/wab/impl/exprs/not.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/expr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/or.rb
+++ b/lib/wab/impl/exprs/or.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/boolexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/exprs/regex.rb
+++ b/lib/wab/impl/exprs/regex.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/pathexpr'
-
 module WAB
   module Impl
 

--- a/lib/wab/impl/model.rb
+++ b/lib/wab/impl/model.rb
@@ -1,8 +1,5 @@
 
 require 'oj'
-require 'wab'
-require 'wab/impl/expr'
-require 'wab/impl/exprparse'
 
 module WAB
   module Impl
@@ -48,9 +45,9 @@ module WAB
         filter = nil
         if tql.has_key?(:where)
           w = tql[:where]
-          where = (w.is_a?(Array) ? Expr.parse(w) : w)
+          where = (w.is_a?(Array) ? ExprParser.parse(w) : w)
         end
-        filter = Expr.parse(tql[:filter]) if tql.has_key?(:filter)
+        filter = ExprParser.parse(tql[:filter]) if tql.has_key?(:filter)
         
         if tql.has_key?(:insert)
           insert(tql[:insert], rid, where, filter)

--- a/lib/wab/impl/path_expr.rb
+++ b/lib/wab/impl/path_expr.rb
@@ -1,6 +1,4 @@
 
-require 'wab/impl/expr'
-
 module WAB
   module Impl
 

--- a/test/test_expr.rb
+++ b/test/test_expr.rb
@@ -3,7 +3,7 @@
 
 require_relative 'helper'
 
-require 'wab/impl/exprparse'
+require 'wab/impl/expr_parser'
 
 require 'test_expr_between'
 require 'test_expr_eq'
@@ -21,15 +21,15 @@ require 'test_expr_or'
 
 class TestExpr < TestImpl
 
-  def test_expr_parse
+  def test_expr_parser_parse
     natives = [
                ['EQ', 'num', 7],
                ['AND', ['HAS', 'str'], ['EQ', 'num', 7]],
               ]
     natives.each { |n|
-      x = ::WAB::Impl::Expr.parse(n)
+      x = ::WAB::Impl::ExprParser.parse(n)
       assert_equal(n, x.native, "parsed failed for #{n}")
     }
   end
 
-end # ExprTest
+end # TestExpr


### PR DESCRIPTION
  - rename `pathexpr`, `boolexpr`, `exprparse` to `path_expr`, `bool_expr`, `expr_parser` respectively
  - handle `require`-ing exprs centrally from within the `Impl` module