### PR TITLE
Replace clone with deep_dup

### DIFF
--- a/lib/wab/data.rb
+++ b/lib/wab/data.rb
@@ -49,7 +49,7 @@ module WAB
     end
 
     # Make a deep copy of the Data instance.
-    def clone()
+    def deep_dup()
       raise NotImplementedError.new
     end
 

--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -173,10 +173,10 @@ module WAB
       end
 
       # Make a deep copy of the Data instance.
-      def clone()
+      def deep_dup()
         # avoid validation by using a empty Hash for the intial value.
         c = self.class.new({}, false)
-        c.instance_variable_set(:@root, clone_value(@root))
+        c.instance_variable_set(:@root, deep_dup_value(@root))
         c
       end
 
@@ -412,13 +412,13 @@ module WAB
         raise WAB::Error, "path key must be an integer for an Array."
       end
 
-      def clone_value(value)
+      def deep_dup_value(value)
         if value.is_a?(Hash)
           c = {}
-          value.each_pair { |k, v| c[k] = clone_value(v) }
+          value.each_pair { |k, v| c[k] = deep_dup_value(v) }
         elsif value.is_a?(Array)
           c = []
-          value.each { |v| c << clone_value(v) }
+          value.each { |v| c << deep_dup_value(v) }
         else
           value_class = value.class
           if value.nil? ||
@@ -431,7 +431,7 @@ module WAB
           elsif WAB::Utils.pre_24_fixnum?(value)
             c = value
           else
-            c = value.clone
+            c = value.dup
           end
         end
         c

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -228,9 +228,9 @@ class TestImplData < TestImpl
     assert(!(d == d4), "same keys different values should not be eql")
   end
 
-  def test_clone
+  def test_deep_dup
     d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
-    c = d.clone
+    c = d.deep_dup
     assert(d == c)
   end
 


### PR DESCRIPTION
The clone method as defined for the base Object is defined to be a
shallow duplicate as well as cloning the frozen state. By replacing
the Data#clone with Data#deep_dup there is no long a conflict with
definitions.