### PR TITLE
Abstract shell-logger methods to a module

### DIFF
--- a/lib/wab.rb
+++ b/lib/wab.rb
@@ -6,6 +6,7 @@ end
 require 'wab/controller'
 require 'wab/data'
 require 'wab/errors'
+require 'wab/shell_logger'
 require 'wab/shell'
 require 'wab/uuid'
 require 'wab/utils'

--- a/lib/wab/impl/shell.rb
+++ b/lib/wab/impl/shell.rb
@@ -1,6 +1,5 @@
 
 require 'webrick'
-require 'logger'
 
 require 'wab'
 require 'wab/impl/model'
@@ -99,8 +98,9 @@ module WAB
 
     # The shell for reference Ruby implementation.
     class Shell
+      include WAB::ShellLogger
+
       attr_accessor :verbose
-      attr_accessor :logger
 
       # Returns the path where a data type is located. The default is 'kind'.
       attr_reader :type_key
@@ -206,42 +206,6 @@ module WAB
       # Calls the model.
       def query(tql, handler=nil)
         @model.query(tql)
-      end
-
-      # Returns true if error logging is turned on.
-      def error?
-        @logger.error?
-      end
-
-      # Returns true if warn logging is turned on.
-      def warn?
-        @logger.warn?
-      end
-
-      # Returns true if info logging is turned on.
-      def info?
-        @logger.info?
-      end
-
-      # Logs an error with the shell logger.
-      #
-      # message:: message to log
-      def error(message)
-        @logger.error(message)
-      end
-
-      # Logs a warning with the shell logger.
-      #
-      # message:: message to log
-      def warn(message)
-        @logger.warn(message)
-      end
-
-      # Logs an info with the shell logger.
-      #
-      # message:: message to log
-      def info(message)
-        @logger.info(message)
       end
 
     end # Shell

--- a/lib/wab/io/shell.rb
+++ b/lib/wab/io/shell.rb
@@ -12,11 +12,11 @@ module WAB
     # calls are synchronous for simplicity some effort is required to block
     # where needed to achieve the difference in behavior.
     class Shell
+      include WAB::ShellLogger
 
       attr_reader :path_pos
       attr_reader :type_key
       attr_accessor :timeout
-      attr_accessor :logger
       
       # Sets up the shell with the designated number of processing threads and
       # the type_key.
@@ -136,42 +136,6 @@ module WAB
       # filter:: the filter to apply to the data. Syntax is that TQL uses for the FILTER clause.
       def subscribe(controller, filter)
         raise NotImplementedError.new
-      end
-
-      # Returns true if error logging is turned on.
-      def error?
-        @logger.error?
-      end
-
-      # Returns true if warn logging is turned on.
-      def warn?
-        @logger.warn?
-      end
-
-      # Returns true if info logging is turned on.
-      def info?
-        @logger.info?
-      end
-
-      # Logs an error with the shell logger.
-      #
-      # message:: message to log
-      def error(message)
-        @logger.error(message)
-      end
-
-      # Logs a warning with the shell logger.
-      #
-      # message:: message to log
-      def warn(message)
-        @logger.warn(message)
-      end
-
-      # Logs an info with the shell logger.
-      #
-      # message:: message to log
-      def info(message)
-        @logger.info(message)
       end
 
       private

--- a/lib/wab/shell.rb
+++ b/lib/wab/shell.rb
@@ -16,6 +16,7 @@ module WAB
   # management but those features can be implemented in other ways as long as
   # the methods remain the same.
   class Shell
+    include WAB::ShellLogger
 
     # Returns the path where a data type is located. The default is 'kind'.
     def type_key()
@@ -80,42 +81,6 @@ module WAB
     # controller:: the controller to notify of changed
     # filter:: the filter to apply to the data. Syntax is that TQL uses for the FILTER clause.
     def subscribe(controller, filter)
-      raise NotImplementedError.new
-    end
-
-    # Returns true if error logging is turned on.
-    def error?
-      raise NotImplementedError.new
-    end
-
-    # Returns true if warn logging is turned on.
-    def warn?
-      raise NotImplementedError.new
-    end
-
-    # Returns true if info logging is turned on.
-    def info?
-      raise NotImplementedError.new
-    end
-
-    # Logs an error with the shell logger.
-    #
-    # message:: message to log
-    def error(message)
-      raise NotImplementedError.new
-    end
-
-    # Logs a warning with the shell logger.
-    #
-    # message:: message to log
-    def warn(message)
-      raise NotImplementedError.new
-    end
-
-    # Logs an info with the shell logger.
-    #
-    # message:: message to log
-    def info(message)
       raise NotImplementedError.new
     end
     

--- a/lib/wab/shell.rb
+++ b/lib/wab/shell.rb
@@ -16,7 +16,6 @@ module WAB
   # management but those features can be implemented in other ways as long as
   # the methods remain the same.
   class Shell
-    include WAB::ShellLogger
 
     # Returns the path where a data type is located. The default is 'kind'.
     def type_key()
@@ -83,6 +82,42 @@ module WAB
     def subscribe(controller, filter)
       raise NotImplementedError.new
     end
-    
+
+    # Returns true if error logging is turned on.
+    def error?
+      raise NotImplementedError.new
+    end
+
+    # Returns true if warn logging is turned on.
+    def warn?
+      raise NotImplementedError.new
+    end
+
+    # Returns true if info logging is turned on.
+    def info?
+      raise NotImplementedError.new
+    end
+
+    # Logs an error with the shell logger.
+    #
+    # message:: message to log
+    def error(message)
+      raise NotImplementedError.new
+    end
+
+    # Logs a warning with the shell logger.
+    #
+    # message:: message to log
+    def warn(message)
+      raise NotImplementedError.new
+    end
+
+    # Logs an info with the shell logger.
+    #
+    # message:: message to log
+    def info(message)
+      raise NotImplementedError.new
+    end
+
   end # Shell
 end # WAB

--- a/lib/wab/shell_logger.rb
+++ b/lib/wab/shell_logger.rb
@@ -1,0 +1,13 @@
+require 'forwardable'
+require 'logger'
+
+module WAB
+  # mixin module meant to be 'included' into `WAB::Shell`, `WAB::IO::Shell`
+  # and `WAB::Impl::Shell`
+  module ShellLogger
+    attr_accessor :logger
+
+    extend Forwardable
+    def_delegators :@logger, :info?, :warn?, :error?, :info, :warn, :error
+  end
+end


### PR DESCRIPTION
Move shell-logger methods to a module instead of defining them multiple times