### PR TITLE
Simplify WAB::Data

### DIFF
--- a/lib/wab/data.rb
+++ b/lib/wab/data.rb
@@ -9,6 +9,14 @@ module WAB
   # class (has the same methods and behavior).
   class Data
 
+    # Returns true if the Data element or value identified by the path
+    # exists where the path elements are separated by the '.' character. The
+    # path can also be a array of path node identifiers. For example,
+    # child.grandchild is the same as ['child', 'grandchild'].
+    def has?(path)
+      raise NotImplementedError.new
+    end
+
     # Gets the Data element or value identified by the path where the path
     # elements are separated by the '.' character. The path can also be a
     # array of path node identifiers. For example, child.grandchild is the
@@ -56,27 +64,6 @@ module WAB
     # Returns the instance converted to native Ruby values such as a Hash,
     # Array, etc.
     def native()
-      raise NotImplementedError.new
-    end
-
-    # Returns true if self and other are either the same or have the same
-    # contents. This is a deep comparison.
-    def eql?(other)
-      raise NotImplementedError.new
-    end
-
-    # Returns the length of the root element.
-    def length()
-      raise NotImplementedError.new
-    end
-
-    # Returns the number of leaves in the data tree.
-    def leaf_count()
-      raise NotImplementedError.new
-    end
-
-    # Returns the number of nodes in the data tree.
-    def size()
       raise NotImplementedError.new
     end
 

--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -180,31 +180,6 @@ module WAB
         c
       end
 
-      # Returns true if self and other are either the same or have the same
-      # contents. This is a deep comparison.
-      def eql?(other)
-        # Any object that is of a class derived from the API class is a
-        # candidate for being ==.
-        return false unless other.is_a?(::WAB::Data)
-        values_eql?(@root, other.native)
-      end
-      alias == eql?
-      
-      # Returns the length of the root element.
-      def length()
-        @root.length
-      end
-
-      # Returns the number of leaves in the data tree.
-      def leaf_count()
-        branch_count(@root)
-      end
-
-      # Returns the number of nodes in the data tree.
-      def size()
-        branch_size(@root)
-      end
-
       # Encode the data as a JSON string.
       def json(indent=0)
         Oj.dump(@root, mode: :wab, indent: indent)
@@ -356,46 +331,6 @@ module WAB
           value.each_index { |i| each_leaf_node(path + [i], value[i], block) }
         else
           block.call(path, value)
-        end
-      end
-
-      def branch_count(value)
-        cnt = 0
-        if value.is_a?(Hash)
-          value.each_value { |v| cnt += branch_count(v) }
-        elsif value.is_a?(Array)
-          value.each { |v| cnt += branch_count(v) }
-        else
-          cnt = 1
-        end
-        cnt
-      end
-
-      def branch_size(value)
-        cnt = 1
-        if value.is_a?(Hash)
-          value.each_value { |v| cnt += branch_size(v) }
-        elsif value.is_a?(Array)
-          value.each { |v| cnt += branch_size(v) }
-        end
-        cnt
-      end
-
-      def values_eql?(v0, v1)
-        return false unless v0.class == v1.class
-        if v0.is_a?(Hash)
-          return false unless v0.length == v1.length
-          v0.each_key { |k|
-            return false unless values_eql?(v0[k], v1[k])
-            return false unless v1.has_key?(k)
-          }
-        elsif v0.is_a?(Array)
-          return false unless v0.length == v1.length
-          v0.each_index { |i|
-            return false unless values_eql?(v0[i], v1[i])
-          }
-        else
-          v0 == v1
         end
       end
 

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -138,61 +138,6 @@ class TestImplData < TestImpl
     assert_equal(%|{"a":1,"b":["a","b","c"]}|, d.json())
   end
 
-  def test_hash_length
-    d = @shell.data({a: 1, b: 2})
-    assert_equal(2, d.length())
-  end
-
-  def test_array_length
-    d = @shell.data(['a', 'b', 'c'])
-    assert_equal(3, d.length())
-  end
-
-  def test_mixed_length
-    d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
-    assert_equal(2, d.length())
-  end
-
-  def test_empty_leaf_count
-    d = @shell.data()
-    assert_equal(0, d.leaf_count())
-  end
-
-  def test_hash_leaf_count
-    d = @shell.data({a: 1, b: 2, c:{}})
-    assert_equal(2, d.leaf_count())
-  end
-
-  def test_array_leaf_count
-    d = @shell.data(['a', 'b', 'c', []])
-    assert_equal(3, d.leaf_count())
-  end
-
-  def test_mixed_leaf_count
-    d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
-    assert_equal(4, d.leaf_count())
-  end
-
-  def test_empty_size
-    d = @shell.data()
-    assert_equal(1, d.size())
-  end
-
-  def test_hash_size
-    d = @shell.data({a: 1, b: 2, c:{}})
-    assert_equal(4, d.size())
-  end
-
-  def test_array_size
-    d = @shell.data(['a', 'b', 'c', []])
-    assert_equal(5, d.size())
-  end
-
-  def test_mixed_size
-    d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
-    assert_equal(7, d.size())
-  end
-
   def test_each
     d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
     paths = []
@@ -223,15 +168,15 @@ class TestImplData < TestImpl
     d3 = @shell.data({a: 1, b: ['a', 'b', { d: 3}]})
     d4 = @shell.data({a: 1, b: ['a', 'b', { c: 4}]})
 
-    assert(d == d2, "same keys and values should be eql")
-    assert(!(d == d3), "same values different keys should not be eql")
-    assert(!(d == d4), "same keys different values should not be eql")
+    assert(d.native == d2.native, "same keys and values should be eql")
+    assert(!(d.native == d3.native), "same values different keys should not be eql")
+    assert(!(d.native == d4.native), "same keys different values should not be eql")
   end
 
   def test_deep_dup
     d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
     c = d.deep_dup
-    assert(d == c)
+    assert(d.native == c.native)
   end
 
   def test_detect


### PR DESCRIPTION
4 methods were removed, eql? and the size or length methods since
they are not used in normal operations and can easily be replaced by
converting data to native. This simplifies implementing a WAB::Data
alternative. The has? method was added as it is needed to determine
if a value exists on a path.