### PR TITLE
Sample for opo-rub

### DIFF
--- a/examples/sample/.gitignore
+++ b/examples/sample/.gitignore
@@ -1,2 +1,3 @@
 log
 opo/data
+wabur/data

--- a/examples/sample/README.md
+++ b/examples/sample/README.md
@@ -63,12 +63,12 @@ verbosity.
 ### OpO-Rub
 
 OpO-Rub provides the HTTP server and the Model storage, and is able to run the
-an an embedded Ruby application.
+an embedded Ruby application.
 
 OpO-Rub can be downloaded from
 [OpO Downloads](http://www.opo.technology/download/index.html).
 
-The confguration file for OpO-Rub is in the `opo` sub-directory, and is named
+The configuration file for OpO-Rub is in the `opo` sub-directory, and is named
 [`embed.conf`](opo/embed.conf). The configuration specifies that the OpO-Rub
 disk storage be in the `opo/data` directory. It also turns on logging for HTTP
 requests and responses along with handler information from the Runner's

--- a/examples/sample/README.md
+++ b/examples/sample/README.md
@@ -201,7 +201,7 @@ with an average latency of 0.134 msecs
 
 ```
 
-Keep the connection alive it were the same browsers performing multiple fetchs.
+Keep the connection alive as if it were the same browsers performing multiple fetchs.
 ```
 > hose -t 2 -c 20 -p json/000000000000000b 127.0.0.1:6363 -k
 127.0.0.1:6363 processed 347951 requests in 1.000 seconds for a rate of 347951 GETS/sec.
@@ -219,7 +219,7 @@ Closing the connection after each fetch as if it were separate browsers.
 with an average latency of 2.997 msecs
 ```
 
-Keep the connection alive it were the same browsers performing multiple fetchs.
+Keep the connection alive as if it were the same browsers performing multiple fetchs.
 ```
 > hose -t 2 -c 20 -p v1/Article/11 127.0.0.1:6363 -k
 127.0.0.1:6363 did not respond to 2 requests.
@@ -239,7 +239,7 @@ with an average latency of 0.247 msecs
 
 ```
 
-Keep the connection alive it were the same browsers performing multiple fetchs.
+Keep the connection alive as if it were the same browsers performing multiple fetchs.
 
 ```
 > hose -t 2 -c 20 -p e1/Article/11 127.0.0.1:6363 -k

--- a/examples/sample/README.md
+++ b/examples/sample/README.md
@@ -24,7 +24,8 @@ The Sample App can be tested on a local browser with Javascript enabled, and
 can be served with choice between the following runners:
 
   * a pure [Ruby Runner](#ruby-runner), built using `WEBrick`
-  * a high-performance runner written in C, [OpO](#opo) (*Not supported on Windows*).
+  * a high-performance spawning/forking runner written in C, [OpO](#opo) (*Not supported on Windows*).
+  * a high-performance embedded Ruby runner written in C, [OpO-Rub](#opo-rub) (*Not supported on Windows*).
 
 Additionally, the files necessary to render the App view needs to be compiled
 from their source. The source files are located in the [`view`](../../view)
@@ -59,6 +60,20 @@ Near the bottom of the conf file, the Controller `spawn.rb` is mentioned
 along with command line options. The `-v` option turns on Controller
 verbosity.
 
+### OpO-Rub
+
+OpO-Rub provides the HTTP server and the Model storage, and is able to run the
+an an embedded Ruby application.
+
+OpO-Rub can be downloaded from
+[OpO Downloads](http://www.opo.technology/download/index.html).
+
+The confguration file for OpO-Rub is in the `opo` sub-directory, and is named
+[`embed.conf`](opo/embed.conf). The configuration specifies that the OpO-Rub
+disk storage be in the `opo/data` directory. It also turns on logging for HTTP
+requests and responses along with handler information from the Runner's
+perspective.
+
 ### Running the App
 
 Compiling and running the App with a runner of your choice can be easily
@@ -77,7 +92,6 @@ It accepts two options:
 The Sample App has been configured on both runners to serve at
 `http://localhost:6363` by default and can changed in the concerned config
 files.
-
 
 ## Running without a browser
 
@@ -161,7 +175,7 @@ There are two ways to get the JSON of the created record:
 Now that a record has been created, the benchmarks can be run.
 
 ```
-> hose -p "tree/000000000000000b" -d 1.0 -t 2 127.0.0.1:6363
+> hose -p "json/000000000000000b" -d 1.0 -t 2 127.0.0.1:6363
 ```
 
 ```
@@ -173,35 +187,31 @@ connections at a time to the Runner.
 
 ### Results
 
-Benchmarks were run on a Razer Blade Stealth laptop with Ubuntu 17.04. A nice
-machine but still a laptop and not a server class machine by any stretch. A
-second set is on a desktop with an i7-6700@4.00GHz with 4 cores (8
+Benchmarks were run on a desktop with an i7-6700@4.00GHz with 4 cores (8
 hyperthreads.
 
 #### Direct DB access
 
 ```
-razer bin> ./hose -p tree/000000000000000b -t 2 -c 20 127.0.0.1:6363
-127.0.0.1:6363 processed 100292 requests in 1.000 seconds for a rate of 100292 GETS/sec.
-with an average latency of 0.254 msecs
-
-big bin> hose -t 2 -c 20 -p tree/000000000000000b localhost:6363
+> hose -t 2 -c 20 -p json/000000000000000b localhost:6363
 localhost:6363 processed 157075 requests in 1.000 seconds for a rate of 157075 GETS/sec.
 with an average latency of 0.162 msecs
 
 ```
 
-#### Controller with 4 Ruby Thread
+#### IO Controller with 4 Ruby Thread
 
 ```
-razer bin> ./hose -p v1/Article/11 -t 2 -c 20 127.0.0.1:6363
-127.0.0.1:6363 did not respond to 3 requests.
-127.0.0.1:6363 processed 10200 requests in 1.000 seconds for a rate of 10200 GETS/sec.
-with an average latency of 4.249 msecs
-
-big bin> hose -t 2 -c 20 -p v1/Article/11 localhost:6363
+> hose -t 2 -c 20 -p v1/Article/11 localhost:6363
 localhost:6363 did not respond to 1 requests.
 localhost:6363 processed 17569 requests in 1.000 seconds for a rate of 17569 GETS/sec.
 with an average latency of 2.963 msecs
+
+```
+
+#### Embedded Controller
+
+```
+TBD
 
 ```

--- a/examples/sample/README.md
+++ b/examples/sample/README.md
@@ -192,26 +192,69 @@ hyperthreads.
 
 #### Direct DB access
 
-```
-> hose -t 2 -c 20 -p json/000000000000000b localhost:6363
-localhost:6363 processed 157075 requests in 1.000 seconds for a rate of 157075 GETS/sec.
-with an average latency of 0.162 msecs
+Closing the connection after each fetch as if it were separate browsers.
 
+```
+> hose -t 2 -c 20 -p json/000000000000000b 127.0.0.1:6363
+127.0.0.1:6363 processed 159321 requests in 1.000 seconds for a rate of 159321 GETS/sec.
+with an average latency of 0.134 msecs
+
+```
+
+Keep the connection alive it were the same browsers performing multiple fetchs.
+```
+> hose -t 2 -c 20 -p json/000000000000000b 127.0.0.1:6363 -k
+127.0.0.1:6363 processed 347951 requests in 1.000 seconds for a rate of 347951 GETS/sec.
+with an average latency of 0.111 msecs
 ```
 
 #### IO Controller with 4 Ruby Thread
 
-```
-> hose -t 2 -c 20 -p v1/Article/11 localhost:6363
-localhost:6363 did not respond to 1 requests.
-localhost:6363 processed 17569 requests in 1.000 seconds for a rate of 17569 GETS/sec.
-with an average latency of 2.963 msecs
+Closing the connection after each fetch as if it were separate browsers.
 
+```
+> hose -t 2 -c 20 -p v1/Article/11 127.0.0.1:6363
+127.0.0.1:6363 did not respond to 3 requests.
+127.0.0.1:6363 processed 14433 requests in 1.000 seconds for a rate of 14433 GETS/sec.
+with an average latency of 2.997 msecs
+```
+
+Keep the connection alive it were the same browsers performing multiple fetchs.
+```
+> hose -t 2 -c 20 -p v1/Article/11 127.0.0.1:6363 -k
+127.0.0.1:6363 did not respond to 2 requests.
+127.0.0.1:6363 processed 13837 requests in 1.000 seconds for a rate of 13837 GETS/sec.
+with an average latency of 3.346 msecs
 ```
 
 #### Embedded Controller
 
-```
-TBD
+Closing the connection after each fetch as if it were separate browsers.
 
 ```
+> hose -t 2 -c 20 -p e1/Article/11 127.0.0.1:6363   
+127.0.0.1:6363 processed 137603 requests in 1.000 seconds for a rate of 137603 GETS/sec.
+with an average latency of 0.247 msecs
+
+
+```
+
+Keep the connection alive it were the same browsers performing multiple fetchs.
+
+```
+> hose -t 2 -c 20 -p e1/Article/11 127.0.0.1:6363 -k
+127.0.0.1:6363 processed 227789 requests in 1.000 seconds for a rate of 227789 GETS/sec.
+with an average latency of 0.171 msecs
+```
+
+#### Summary
+
+At more than 300K fetches per second the direct access with keep-alive
+connections is clearly the fastest of the bunch but it bypasses the Ruby
+controller. Of the two remaining, the use of embedded Ruby gives excellent
+results that surpass the 100K fetch per second goal by a sizeable amount at
+more than double the goal with keep-alive and nearly 40% over target with
+connection closes.
+
+Some issues still remain with the stdio approach dropping 2 messages out of
+14K.

--- a/examples/sample/opo/bench.conf
+++ b/examples/sample/opo/bench.conf
@@ -6,7 +6,7 @@
 
 # The directory to store the opo data.
 #dir = /var/opo
-dir = opo/data
+dir = examples/sample/opo/data
 
 # A journal is kept if this option is true. When set to false changes in the
 # data are not persisted until a clean exit or a explicit persist command to
@@ -39,7 +39,7 @@ http.port = 6363
 # take precedence over subdirectories in the provided pages dir. If left blank
 # then no custom pages are served.
 #http.dir =
-http.dir = pages
+http.dir = view/pages
 
 ################################################################################
 # Log related options are all prefixed with 'log.'. Log files are written to a
@@ -48,7 +48,7 @@ http.dir = pages
 
 # The directory to write log files to.
 #log.dir = /var/log
-log.dir = log
+log.dir = examples/sample/opo/log
 
 # The maximum number of archived log files to keep in addition to the current
 # log file.
@@ -214,8 +214,24 @@ ns.xsd = http://www.w3.org/2001/XMLSchema#
 # string to the respective native type. A comma separated list is expected.
 type.prefixes = http://www.w3.org/2001/XMLSchema#,http://www.w3.org/TR/xmlschema11-2/#,http://www.w3.org/TR/xmlschema-2/#
 
-handler.sample.path = /Article/**
+handler.sample.path = /v1/**
 handler.sample.max_out = 10
-handler.sample.cmd = spawn.rb -I ../../lib -t 4
+handler.sample.cmd = examples/sample/spawn.rb -I lib -t 4
 #handler.sample.cmd = spawn.rb -v
 handler.sample.timeout = 5.0
+
+handler.embed.path = /e1/**
+# An embedded handler is denoted by a class value.
+handler.embed.class = SampleController
+
+################################################################################
+# When using opo-rub or other opo version with embedded interpreters the
+# 'embed' options can be used. The handler options are also extended to
+# support calling the embedded interpreter.
+
+embed.load_path = .,lib,examples/sample
+embed.require = sample
+embed.setup = puts 'Ruby Started'
+embed.cleanup = puts 'Ruby Finished'
+embed.type_key = kind
+embed.path_pos = 1

--- a/examples/sample/opo/embed.conf
+++ b/examples/sample/opo/embed.conf
@@ -59,7 +59,7 @@ log.dir = examples/sample/opo/log
 log.maxFiles = 3
 
 # Size that when exceeded cause the log files to rotate. Note file may and are
-# usually slightly larger than the maximum size as the the maximum size is a
+# usually slightly larger than the maximum size as the maximum size is a
 # trigger to rotate.
 log.maxSize = 100000000
 

--- a/examples/sample/opo/embed.conf
+++ b/examples/sample/opo/embed.conf
@@ -14,10 +14,10 @@ dir = examples/sample/opo/data
 journal = false
 
 # If sync is true then writes are always synced to disk before
-# returning. Performance is far better is sync is set to false.
+# returning. Performance is far better if sync is set to false.
 sync = false
 
-# If exit_sync is true then writes are performed on normall shutdown or by
+# If exit_sync is true then writes are performed on normal shutdown or by
 # ctrl-C unless journalling is already on or sync is true.
 exit_sync = true
 
@@ -66,7 +66,7 @@ log.maxSize = 100000000
 # If true log entries are displayed on the console.
 log.console = true
 
-# if true console log out is in classic format. If false output is in JSON
+# if true console log output is in classic format. If false, output is in JSON
 # format.
 log.classic = true
 
@@ -74,7 +74,7 @@ log.classic = true
 log.colorize = true
 
 # If the syslog address and port in the format 10.10.0.7:1234 is provided log
-# messages are also send to syslog on the provided address. If the UDP option
+# messages are also sent to syslog on the provided address. If the UDP option
 # is true the syslog send is done using UDP instead of TCP.
 log.syslog.address = 
 log.syslog.udp = true

--- a/examples/sample/opo/embed.conf
+++ b/examples/sample/opo/embed.conf
@@ -1,0 +1,245 @@
+# opo.conf
+
+# This sample configuration file for opod includes all the avaliable options
+# and the default values for those options. All option keys are case
+# insensitive.
+
+# The directory to store the opo data.
+#dir = /var/opo
+dir = examples/sample/opo/data
+
+# A journal is kept if this option is true. When set to false changes in the
+# data are not persisted until a clean exit or a explicit persist command to
+# the opod.
+journal = false
+
+# If sync is true then writes are always synced to disk before
+# returning. Performance is far better is sync is set to false.
+sync = false
+
+# If exit_sync is true then writes are performed on normall shutdown or by
+# ctrl-C unless journalling is already on or sync is true.
+exit_sync = true
+
+# Default format for import and dump. Valid values are JSON, RDF, N-TRiPLES,
+# N-QUADS, TURTLE, or OG, case insensitive. The indent option if for the JSON
+# format only.
+format = JSON
+
+# One or more threads are created to process requests. Set the threads to the
+# value best suited to the machine opo will be running on.
+threads = 2
+
+################################################################################
+# Opo supports an HTTP interface. The HTTP interface includes documentation
+# pages, access helper pages, and REST APIs for interating with opo using
+# either a JSON model of SPARQL when using the triple store model.
+
+# The port to connect to opo on using an HTTP browser. A value of zero
+# indicates no HTTP connectivity.
+http.port = 6363
+
+# Opo can also be used to serve custom pages. Note that built in URL paths
+# take precedence over subdirectories in the provided pages dir. If left blank
+# then no custom pages are served.
+#http.dir =
+http.dir = view/pages
+
+################################################################################
+# Log related options are all prefixed with 'log.'. Log files are written to a
+# specified log directory and rotated as they exceed the maximum size. Log
+# files are in JSON format.
+
+# The directory to write log files to.
+#log.dir = /var/log
+log.dir = examples/sample/opo/log
+
+# The maximum number of archived log files to keep in addition to the current
+# log file.
+log.maxFiles = 3
+
+# Size that when exceeded cause the log files to rotate. Note file may and are
+# usually slightly larger than the maximum size as the the maximum size is a
+# trigger to rotate.
+log.maxSize = 100000000
+
+# If true log entries are displayed on the console.
+log.console = true
+
+# if true console log out is in classic format. If false output is in JSON
+# format.
+log.classic = true
+
+# If true console output is colorized.
+log.colorize = true
+
+# If the syslog address and port in the format 10.10.0.7:1234 is provided log
+# messages are also send to syslog on the provided address. If the UDP option
+# is true the syslog send is done using UDP instead of TCP.
+log.syslog.address = 
+log.syslog.udp = true
+
+# Logging category or feature based. To log details about specific features
+# turn the category on. Colors can also be set for each category. Supported
+# colors are:
+#   black
+#   red
+#   green
+#   yellow
+#   blue
+#   magenta
+#   cyan
+#   white
+#   gray
+#   dark_red
+#   dark_green
+#   brown
+#   dark_blue
+#   purple
+#   dark_cyan
+
+# The error category.
+log.cats.error.on = true
+log.cats.error.color = red
+
+# The warning category.
+log.cats.warn.on = true
+log.cats.warn.color = yellow
+
+# The mod category is used to log changes or modifications to data in the
+# store. Any insert, update, and delete is logged if true.
+log.cats.mod.on = true
+log.cats.mod.color = dark_green
+
+# The journal category. A log message is published for ever journal
+# entry. Very verbose.
+log.cats.journal.on = false
+log.cats.journal.color = dark_green
+
+# Logging for http is controlled by these options. Note that HTTP logging is
+# finer grained that others.
+log.cats.http_request.on = true
+log.cats.http_request.color = dark_green
+
+log.cats.http_response.on = true
+log.cats.http_response.color = dark_green
+
+log.cats.http_debug.on = false
+log.cats.http_debug.color = purple
+
+log.cats.handler.on = true
+log.cats.handler.color = blue
+#
+###############################################################################
+# Opo is a triple store but also supports JSON imports and exports. RDF is
+# also supported. To provide a mapping from one to the other several options
+# are included.
+
+# When JSON is generated for query responses it will be indented according to
+# this option.
+json.indent = 0
+
+# Opo data types include more types than supported by JSON natively. The JSON
+# detect options control what the JSON parse does when it encounters a value
+# that could be read as a different type.
+
+# A value starting with http:// will be treated as a IRI if this option is true.
+json.detect.iri = true
+
+# If true a string that has the form that matches RFC3339 will be converted to
+# a date-time. Examples are: 2017-01-05T12:34:56+07:00, 2017-01-05T12:34:56Z
+# and 2017-01-05T12:34:56.999999999-07:00.
+json.detect.time.string = true
+
+# Time is stored as UNIX UTC internally. Time zones are not stored. The time
+# format options allow the time format and time zone to be used in the output
+# strings or numbers. Options for time format are:
+# UNIX: seconds from UTC epoch with 9 decimal places for seconds
+# UNIX6: seconds from UTC epoch with 6 decimal places for seconds
+# UNIX3: seconds from UTC epoch with 3 decimal places for seconds
+# UNIX0: seconds from UTC epoch with no decimal places for seconds
+# XSD9: XSD date-time with 9 decimal places for seconds
+# XSD6: XSD date-time with 6 decimal places for seconds
+# XSD3: XSD date-time with 3 decimal places for seconds
+# XSD0: XSD date-time with no decimal places for seconds
+# XSD: XSD date-time with up to 9 decimal places for seconds. trailing 0 are stripped
+# DATE: XSD date-time with up to 9 decimal places for seconds. trailing 0 are
+#           stripped. If hours, minutes, and seconds are 0 then only the date
+#           portion is output.
+time.format = XSD
+time.zone = 0
+
+# A value that has the format of a UUID (123e4567-e89b-12d3-a456-426655440000)
+# be treated as a UUID if this option is true. Providing a slight performance
+# improvment with UUIDs.
+json.detect.uuid = true
+
+# It is common for numbers to be used for times as well. A few extra control
+# parameters are needed to limit the scope of time detection. The min and max
+# values specify the range for detection. The decimals if non-zero sets up a
+# requirement for that specific number of decimal places that must match.
+json.detect.time.number.on = true
+json.detect.time.number.min = 1400000000
+json.detect.time.number.max = 1600000000
+json.detect.time.number.decimals = 9
+
+# JSON imports are converted to triples but not RDF compliant triples. In an
+# RDF triple the subject must be either a blank or a IRI. The predicate must
+# be a IRI. Since imported JSONs do not have namespaces associated with them a
+# default namespace is used to make the JSON literals into IRIs using a
+# default namespace.
+rdf.default.namespace = http://localhost#
+
+################################################################################
+# IRI aliases can be registered. These aliases will take precedence over any
+# prefix defined in a TURTLE import. Note that the commented out sample are
+# most likely out of date. Thats one of the problems with including the date
+# in the URL. It is also an advantage is referring to an older specification.
+ns.dct = http://purl.org/dc/terms/
+ns.foaf = http://xmlns.com/foaf/0.1/
+ns.gr = http://purl.org/goodrelations/v1#
+ns.org = http://www.w3.org/ns/org#
+ns.owl = http://www.w3.org/2002/07/owl#
+ns.prov = http://www.w3.org/ns/prov#
+ns.rdf = http://www.w3.org/1999/02/22-rdf-syntax-ns#
+ns.rdfs = http://www.w3.org/2000/01/rdf-schema#
+ns.skos = http://www.w3.org/2004/02/skos/core#
+ns.time = http://www.w3.org/2006/time#
+ns.vcard = http://www.w3.org/2006/vcard/ns#
+ns.xsd = http://www.w3.org/2001/XMLSchema#
+#ns.xsd = https://www.w3.org/TR/xmlschema11-2/#
+#ns.xsd = https://www.w3.org/TR/xmlschema-2/#
+
+# N-Triples and N-Quads literal strings can have a type associated with the
+# string. Opo attempts to convert the strings to native types if possible. To
+# do so it looks for know IRI prefixes followed by the type. The supported
+# types are 'integer', 'double', 'time', and 'datetime'. The listed
+# type.prefixes are used to form the IRIs that trigger the conversion of a
+# string to the respective native type. A comma separated list is expected.
+type.prefixes = http://www.w3.org/2001/XMLSchema#,http://www.w3.org/TR/xmlschema11-2/#,http://www.w3.org/TR/xmlschema-2/#
+
+# Multiple handlers can be running at the same time if using different
+# paths. The view conf.js would have to change to use one path or the other by
+# setting the wab.pathPrefix value.
+
+#handler.sample.path = /v1/**
+#handler.sample.max_out = 10
+#handler.sample.cmd = examples/sample/spawn.rb -I lib -t 4
+#handler.sample.cmd = spawn.rb -v
+#handler.sample.timeout = 5.0
+
+handler.embed.path = /v1/**
+# An embedded handler is denoted by a class value.
+handler.embed.class = SampleController
+
+################################################################################
+# When using opo-rub or other opo version with embedded interpreters the
+# 'embed' options can be used. The handler options are also extended to
+# support calling the embedded interpreter.
+
+embed.load_path = .,lib,examples/sample
+embed.require = sample
+embed.setup = puts 'Ruby Started'
+embed.cleanup = puts 'Ruby Finished'
+embed.type_key = kind
+embed.path_pos = 1

--- a/examples/sample/opo/embed.conf
+++ b/examples/sample/opo/embed.conf
@@ -225,7 +225,6 @@ type.prefixes = http://www.w3.org/2001/XMLSchema#,http://www.w3.org/TR/xmlschema
 #handler.sample.path = /v1/**
 #handler.sample.max_out = 10
 #handler.sample.cmd = examples/sample/spawn.rb -I lib -t 4
-#handler.sample.cmd = spawn.rb -v
 #handler.sample.timeout = 5.0
 
 handler.embed.path = /v1/**

--- a/script/start-sample
+++ b/script/start-sample
@@ -34,7 +34,7 @@ set -e
 
 sampledir=examples/sample
 
-while getopts :bo opt
+while getopts :boe opt
 do
   case $opt in
     b)
@@ -45,13 +45,17 @@ do
       echo -e "\n  Starting OpO Daemon.."
       opod -c $sampledir/opo/opo.conf
       ;;
+    e)
+      echo -e "\n  Starting OpO-Rub Daemon.."
+      opo-rub -c $sampledir/opo/embed.conf
+      ;;
   esac
 done
 
 # Start ruby-runner if no args had been passed or if the args did
 # not contain the option to start OpO runner
 
-if [ -z $# ] || [[ $1 != *'o'* ]]
+if [ -z $# ] || [[ $1 != *'o'* && $1 != *'e'* ]]
 then
   echo -e "\n  Starting Ruby Runner.."
   bundle exec wabur -c $sampledir/wabur/wabur.conf

--- a/script/start-sample
+++ b/script/start-sample
@@ -18,7 +18,8 @@
 #
 # Alternatively, a high-performance runner (OpO), available for Linux, OSX
 # platforms can also be run using this script, provided OpO is already
-# installed in the system.
+# installed in the system. There are two varieties, opod which spawns a Ruby
+# app or opo-rub which runs the Ruby code embedded in the runner.
 #
 # The following command compiles source-files and serves with the OpO runner:
 #
@@ -28,6 +29,11 @@
 # compiled source-files:
 #
 #   $ script/run-sample -o
+#
+# To run opo-rub, the following serves the App with the OpO-Rub runner using
+# previously compiled source-files:
+#
+#   $ script/run-sample -e
 # -----------------------------------------------------------------------------
 
 set -e

--- a/view/js/list.js
+++ b/view/js/list.js
@@ -1,6 +1,6 @@
 
 wab.List.prototype.delete = function(ref) {
-    wab.httpCall('DELETE', '/v1/' + this.kind + '/' + ref, this, function(list, resp) {
+    wab.httpCall('DELETE', wab.pathPrefix + this.kind + '/' + ref, this, function(list, resp) {
         wab.view.set(list);
     })
 }
@@ -55,7 +55,7 @@ wab.List.prototype.display = function(view, edit) {
     this.table = table;
     
     // Request content.
-    wab.httpCall('GET', '/v1/' + this.kind + opt, this, function(list, resp) {
+    wab.httpCall('GET', wab.pathPrefix + this.kind + opt, this, function(list, resp) {
         var results = resp.results, btn, bi;
         if (typeof results === 'object') {
             var i, cs, len = list.spec.list.length;

--- a/view/js/obj.js
+++ b/view/js/obj.js
@@ -1,7 +1,7 @@
 
 wab.Obj.prototype.fetch = function() {
     if (0 != this.ref) {
-        wab.httpCall('GET', '/v1/' + this.spec.obj.kind + '/' + this.ref, this, function(o, resp) {
+        wab.httpCall('GET', wab.pathPrefix + this.spec.obj.kind + '/' + this.ref, this, function(o, resp) {
             if (0 != resp.code) {
                 alert(results.error);
                 return;
@@ -94,10 +94,10 @@ wab.Obj.prototype.save = function() {
     
     if (0 == this.ref) {
         method = 'PUT';
-        url = '/v1/' + this.spec.obj.kind;
+        url = wab.pathPrefix + this.spec.obj.kind;
     } else {
         method = 'POST';
-        url = '/v1/' + this.spec.obj.kind + '/' + this.ref;
+        url = wab.pathPrefix + this.spec.obj.kind + '/' + this.ref;
     }
     var h = new XMLHttpRequest();
     h.open(method, url, true);

--- a/view/js/wab.js
+++ b/view/js/wab.js
@@ -2,6 +2,7 @@
 // to minimize page fetchs from the server.
 
 var wab = {
+    pathPrefix: '/v1/',
     View: function() {
         this.view = document.getElementById("view");
         this.page = null;

--- a/view/pages/conf.js
+++ b/view/pages/conf.js
@@ -2,6 +2,8 @@
 // configured first then a call to wab.view.set() is made to draws the initial
 // display.
 
+wab.pathPrefix = '/v1/'
+
 // Example of registering a class by name and template/specificaiton.
 wab.view.register_type('Article',
                        {


### PR DESCRIPTION
The sample was updated so it can be run with opo-rub and embedded Ruby.
The wab.pathPrefix was added to the Javascript to allow both IO and
embedded Ruby controllers to be run at the same time.