### PR TITLE
Prefer single-quoted strings

### DIFF
--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -127,7 +127,7 @@ module WAB
       # value:: value to set
       # repair:: flag indicating invalid value should be repaired if possible
       def set(path, value, repair=false)
-        raise WAB::Error, "path can not be empty." if path.empty?
+        raise WAB::Error, 'path can not be empty.' if path.empty?
         if value.is_a?(::WAB::Data)
           value = value.native
         elsif repair
@@ -316,7 +316,7 @@ module WAB
           value = fix(value)
         elsif value.respond_to?(:to_s)
           value = value.to_s
-          raise StandardError.new("Data values must be either a Hash or an Array") unless value.is_a?(String)
+          raise StandardError.new('Data values must be either a Hash or an Array') unless value.is_a?(String)
         else
           raise WAB::TypeError, "#{value_class} is not a valid Data value."
         end
@@ -352,7 +352,7 @@ module WAB
         end
         return key if WAB::Utils.pre_24_fixnum?(key)
 
-        raise WAB::Error, "path key must be an integer for an Array."
+        raise WAB::Error, 'path key must be an integer for an Array.'
       end
 
       def deep_dup_value(value)

--- a/lib/wab/impl/model.rb
+++ b/lib/wab/impl/model.rb
@@ -163,7 +163,7 @@ module WAB
             rid
           elsif '$' == format || '$root' == format
             obj.native
-          elsif 0 < format.length && '\'' == format[0]
+          elsif 0 < format.length && "'" == format[0]
             format[1..-1]
           else
             obj.get(format)
@@ -184,7 +184,7 @@ module WAB
       def write_to_file(ref, obj)
         return if @dir.nil?
         obj.native if obj.is_a?(::WAB::Data)
-        File.open(File.join(@dir, "%016x.json" % ref), "wb") { |f| f.write(Oj.dump(obj, mode: :wab, indent: 0)) }
+        File.open(File.join(@dir, "%016x.json" % ref), 'wb') { |f| f.write(Oj.dump(obj, mode: :wab, indent: 0)) }
       end
 
       def remove_file(ref)

--- a/lib/wab/utils.rb
+++ b/lib/wab/utils.rb
@@ -5,7 +5,7 @@ module WAB
       TIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{9}Z$/
 
       def ruby_series
-        RbConfig::CONFIG.values_at("MAJOR", "MINOR").join.to_i
+        RbConfig::CONFIG.values_at('MAJOR', 'MINOR').join.to_i
       end
 
       # Detect if `obj` is an instance of `Fixnum` from Ruby older than 2.4.x

--- a/lib/wab/uuid.rb
+++ b/lib/wab/uuid.rb
@@ -11,7 +11,7 @@ module WAB
     # following the pattern "123e4567-e89b-12d3-a456-426655440000".
     def initialize(id)
       @id = id.downcase
-      raise ::WAB::ParseError.new("Invalid UUID format.") unless WAB::Utils.uuid_format?(@id)
+      raise ::WAB::ParseError.new('Invalid UUID format.') unless WAB::Utils.uuid_format?(@id)
     end
 
     # Returns the string representation of the UUID.

--- a/release_wabur
+++ b/release_wabur
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby -wW1
 
-home = File.expand_path(".")
+home = File.expand_path('.')
 name = ARGV.empty? ? File.basename(home) : ARGV[0]
 
-require File.join(home, "lib/wab/version")
+require File.join(home, 'lib/wab/version')
 
 version = WAB::VERSION
 
@@ -24,9 +24,9 @@ unless tags.include?(tag)
   `git push --tags`
 end
 
-log "Building gem.."
+log 'Building gem..'
 out = `gem build #{name}.gemspec`
-out.include?("Success") ? puts(out) : exit(0)
+out.include?('Success') ? puts(out) : exit(0)
 
 log "pushing #{name}-#{version}.gem.."
 out = `gem push #{name}-#{version}.gem`

--- a/script/build-view
+++ b/script/build-view
@@ -87,7 +87,7 @@ def compact_js_line(line)
 end
 
 def path_to(*subdirs)
-  File.expand_path(File.join("..", "view", *subdirs), __dir__)
+  File.expand_path(File.join('..', 'view', *subdirs), __dir__)
 end
 
 def dest_dir(*contents)

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -44,7 +44,7 @@ class TestImplData < TestImpl
 
   def test_repair_keys
     d = @shell.data({ 'a' => 1}, true)
-    assert_equal({a:1}, d.native, "data not repaired")
+    assert_equal({a:1}, d.native, 'data not repaired')
   end
 
   def test_validate_non_hash_array
@@ -62,18 +62,18 @@ class TestImplData < TestImpl
 
   def test_repair_to_s_object
     d = @shell.data({a: 1..3}, true)
-    assert_equal({a:'1..3'}, d.native, "data not repaired")
+    assert_equal({a:'1..3'}, d.native, 'data not repaired')
   end
 
   def test_repair_to_h_object
     d = @shell.data(ToHash.new(1, 2), true)
-    assert_equal({x:1,y:2}, d.native, "data not repaired")
+    assert_equal({x:1,y:2}, d.native, 'data not repaired')
   end
 
   def test_hash_get
     d = @shell.data({a: 1, b: 2})
     assert_equal(2, d.get('b'), "failed to get 'b'")
-    assert_equal(2, d.get([:b]), "failed to get [:b]")
+    assert_equal(2, d.get([:b]), 'failed to get [:b]')
     assert_equal(1, d.get(['a']), "failed to get ['a']")
     assert_nil(d.get(['d']), "failed to get ['d']")
   end
@@ -82,16 +82,16 @@ class TestImplData < TestImpl
     d = @shell.data(['a', 'b', 'c'])
     assert_equal('b', d.get('1'), "failed to get '1'")
     assert_equal('c', d.get(['2']), "failed to get ['2']")
-    assert_equal('b', d.get([1]), "failed to get [1]")
-    assert_equal('a', d.get([0]), "failed to get [0]")
-    assert_equal('c', d.get([-1]), "failed to get [-1]")
-    assert_nil(d.get([4]), "failed to get [4]")
+    assert_equal('b', d.get([1]), 'failed to get [1]')
+    assert_equal('a', d.get([0]), 'failed to get [0]')
+    assert_equal('c', d.get([-1]), 'failed to get [-1]')
+    assert_nil(d.get([4]), 'failed to get [4]')
   end
 
   def test_get_mixed
     d = @shell.data({a: 1, b: ['a', 'b', { c: 3}]})
     assert_equal(3, d.get('b.2.c'), "failed to get 'b.2.c'")
-    assert_equal(3, d.get([:b, 2, 'c']), "failed to get [b, 2, c]")
+    assert_equal(3, d.get([:b, 2, 'c']), 'failed to get [b, 2, c]')
   end
 
   def test_hash_set
@@ -121,15 +121,15 @@ class TestImplData < TestImpl
   def test_array_set
     d = @shell.data(['x'])
     d.set([2], 'd')
-    assert_equal(%|["x",null,"d"]|, d.json(), "after d")
+    assert_equal(%|["x",null,"d"]|, d.json(), 'after d')
     d.set([1], 'c')
-    assert_equal(%|["x","c","d"]|, d.json(), "after c")
+    assert_equal(%|["x","c","d"]|, d.json(), 'after c')
     d.set([0], 'y')
-    assert_equal(%|["y","c","d"]|, d.json(), "after y")
+    assert_equal(%|["y","c","d"]|, d.json(), 'after y')
     d.set([-3], 'b')
-    assert_equal(%|["b","c","d"]|, d.json(), "after b")
+    assert_equal(%|["b","c","d"]|, d.json(), 'after b')
     d.set([-4], 'a')
-    assert_equal(%|["a","b","c","d"]|, d.json(), "after a")
+    assert_equal(%|["a","b","c","d"]|, d.json(), 'after a')
   end
 
   def test_set_mixed
@@ -146,8 +146,8 @@ class TestImplData < TestImpl
       paths << p
       values << v
     }
-    assert_equal([[], [:a], [:b], [:b, 0], [:b, 1], [:b, 2], [:b, 2, :c]], paths, "paths mismatch")
-    assert_equal([{:a=>1, :b=>["a", "b", {:c=>3}]}, 1, ["a", "b", {:c=>3}], "a", "b", {:c=>3}, 3], values, "values mismatch")
+    assert_equal([[], [:a], [:b], [:b, 0], [:b, 1], [:b, 2], [:b, 2, :c]], paths, 'paths mismatch')
+    assert_equal([{:a=>1, :b=>['a', 'b', {:c=>3}]}, 1, ['a', 'b', {:c=>3}], 'a', 'b', {:c=>3}, 3], values, 'values mismatch')
   end
 
   def test_each_leaf
@@ -158,8 +158,8 @@ class TestImplData < TestImpl
       paths << p
       values << v
     }
-    assert_equal([[:a], [:b, 0], [:b, 1], [:b, 2, :c]], paths, "paths mismatch")
-    assert_equal([1, "a", "b", 3], values, "values mismatch")
+    assert_equal([[:a], [:b, 0], [:b, 1], [:b, 2, :c]], paths, 'paths mismatch')
+    assert_equal([1, 'a', 'b', 3], values, 'values mismatch')
   end
 
   def test_eql
@@ -168,9 +168,9 @@ class TestImplData < TestImpl
     d3 = @shell.data({a: 1, b: ['a', 'b', { d: 3}]})
     d4 = @shell.data({a: 1, b: ['a', 'b', { c: 4}]})
 
-    assert(d.native == d2.native, "same keys and values should be eql")
-    assert(!(d.native == d3.native), "same values different keys should not be eql")
-    assert(!(d.native == d4.native), "same keys different values should not be eql")
+    assert(d.native == d2.native, 'same keys and values should be eql')
+    assert(!(d.native == d3.native), 'same values different keys should not be eql')
+    assert(!(d.native == d4.native), 'same keys different values should not be eql')
   end
 
   def test_deep_dup

--- a/test/test_io_shell.rb
+++ b/test/test_io_shell.rb
@@ -38,8 +38,8 @@ class TestIoShell < Minitest::Test
     run_fork_test([
                    [{rid: 'rid-create-error', api: 1, body: {op: 'NEW', path: ['sample'], content: {kind: 'sample', num: 7}}},
                     {rid: '1', api: 3, body: { insert:{ kind: 'sample', num: 7}}}],
-                   [{rid: '1', api: 4, body: {ref: 123, code: -1, error: "something went wrong"}},
-                    {rid: 'rid-create-error', api: 2, body: { code: -1, error: "WAB::Error: error on sample create. something went wrong"}}]
+                   [{rid: '1', api: 4, body: {ref: 123, code: -1, error: 'something went wrong'}},
+                    {rid: 'rid-create-error', api: 2, body: { code: -1, error: 'WAB::Error: error on sample create. something went wrong'}}]
                   ])
   end
 
@@ -73,7 +73,7 @@ class TestIoShell < Minitest::Test
   def test_read_select
     run_fork_test([
                    [{rid: 'rid-read-select', api: 1, body: {op: 'GET', path: ['sample', 'list'], query: { Age: 'num' }}},
-                    {rid: '1', api: 3, body: {where: ['EQ', 'kind', "'sample"], select: { ref: '$ref', Age: "num"}}}],
+                    {rid: '1', api: 3, body: {where: ['EQ', 'kind', "'sample"], select: { ref: '$ref', Age: 'num'}}}],
                    [{rid: '1', api: 4, body: {code: 0, results: [{ref: 12345, Age: 7 }]}},
                     {rid: 'rid-read-select', api: 2, body: {code: 0, results:[{ref: 12345, Age: 7 }]}}]
                   ])

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -22,7 +22,7 @@ require 'wab/io'
 #    runner_test.rb localhost:6363
 # -----------------------------------------------------------------------------
 
-raise ArgumentError, "Host and port not supplied." if ARGV.empty?
+raise ArgumentError, 'Host and port not supplied.' if ARGV.empty?
 
 $host, $port = ARGV[-1].split(':')
 $port = $port.to_i

--- a/wabur.gemspec
+++ b/wabur.gemspec
@@ -6,24 +6,24 @@ require 'date'
 require 'wab/version'
 
 Gem::Specification.new do |s|
-  s.name = "wabur"
+  s.name = 'wabur'
   s.version = ::WAB::VERSION
-  s.authors = "Peter Ohler"
+  s.authors = 'Peter Ohler'
   s.date = Date.today.to_s
-  s.email = "peter@ohler.com"
-  s.homepage = "http://github.com/ohler55/wabur"
-  s.summary = "Web Application Builder"
+  s.email = 'peter@ohler.com'
+  s.homepage = 'http://github.com/ohler55/wabur'
+  s.summary = 'Web Application Builder'
   s.description = %{Web Application Builder }
   s.licenses = ['MIT']
 
   s.bindir = 'bin'
   s.executables << 'wabur'
 
-  s.files = Dir["{lib,test}/**/*.rb"] + ['LICENSE', 'README.md'] + Dir["pages/*.md"] + Dir['bin/*']
-  s.test_files = Dir["test/**/*.rb"]
+  s.files = Dir['{lib,test}/**/*.rb'] + ['LICENSE', 'README.md'] + Dir['pages/*.md'] + Dir['bin/*']
+  s.test_files = Dir['test/**/*.rb']
 
   s.has_rdoc = true
-  s.extra_rdoc_files = ['README.md'] + Dir["pages/*.md"]
+  s.extra_rdoc_files = ['README.md'] + Dir['pages/*.md']
   s.rdoc_options = ['--title', 'WABuR', '--main', 'README.md', '--private']
 
   s.rubyforge_project = 'wabur'


### PR DESCRIPTION
Single-quoted strings unless:
  - need for interpolation
  - special characters (e.g. `\s`, `\n`, `\t`)
  - the string itself contains a single quote (as an apostrophe)