### PR TITLE
Rename `::WAB::` to `WAB::`

### DIFF
--- a/bin/wabur
+++ b/bin/wabur
@@ -32,7 +32,7 @@ opts.on('-c', '--conf String', String, 'configuration file') { |c| cfg_file = c 
 opts.on('-h', '--help', 'Show this display')                 { puts opts.help; Process.exit!(0) }
 opts.parse(ARGV)
 
-class BasicController < ::WAB::Controller
+class BasicController < WAB::Controller
 
   def initialize(shell)
     super(shell)
@@ -81,7 +81,7 @@ if 0 < verbose_cnt
   cfg['verbose'] = v
 end
 
-shell = ::WAB::Impl::Shell.new(cfg)
+shell = WAB::Impl::Shell.new(cfg)
 
 # TBD configure logger better
 shell.logger = Logger.new(STDOUT)

--- a/examples/sample/sample.rb
+++ b/examples/sample/sample.rb
@@ -4,7 +4,7 @@
 require 'wab'
 require 'wab/impl'
 
-class SampleController < ::WAB::Controller
+class SampleController < WAB::Controller
 
   def initialize(shell)
     super(shell)

--- a/examples/sample/spawn.rb
+++ b/examples/sample/spawn.rb
@@ -31,7 +31,7 @@ $opts.on('-h', '--help', 'show this page')                         { $stderr.put
 
 $opts.parse(ARGV)
 
-shell = ::WAB::IO::Shell.new($thread_count, 'kind', 1)
+shell = WAB::IO::Shell.new($thread_count, 'kind', 1)
 shell.logger.level = Logger::INFO if $verbose
 shell.register_controller('Article', SampleController.new(shell))
 shell.register_controller('Other', SampleController.new(shell))

--- a/lib/wab/controller.rb
+++ b/lib/wab/controller.rb
@@ -74,7 +74,7 @@ module WAB
         # Read a single object/record.
         ref = ref.to_i
         obj = @shell.get(ref)
-        obj = obj.native if obj.is_a?(::WAB::Data)
+        obj = obj.native if obj.is_a?(WAB::Data)
         results = []
         results << {id: ref, data: obj} unless obj.nil?
         @shell.data({ code: 0, results: results})
@@ -127,7 +127,7 @@ module WAB
       elsif WAB::Utils.populated_hash?(query)
         tql[:where] = and_where(kind, query)
       else
-        raise ::WAB::Error.new("update on all #{kind} not allowed.")
+        raise WAB::Error.new("update on all #{kind} not allowed.")
       end
       tql[:update] = data.native
       shell_query(tql, kind, 'update')
@@ -166,7 +166,7 @@ module WAB
     #
     # data:: results of the query
     def on_result(data)
-      data = data.native if data.is_a?(::WAB::Data)
+      data = data.native if data.is_a?(WAB::Data)
       $stdout.puts(@shell.data({rid: data[:rid], api: 2, body: data}).json)
       $stdout.flush
     end

--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -10,7 +10,7 @@ module WAB
     # the Data instances are factory created by the Shell and will most likely
     # not be instance of this class but rather a class that is a duck-type of
     # this class (has the same methods and behavior).
-    class Data < ::WAB::Data
+    class Data < WAB::Data
       attr_reader :root
 
       def self.detect_string(s)
@@ -128,7 +128,7 @@ module WAB
       # repair:: flag indicating invalid value should be repaired if possible
       def set(path, value, repair=false)
         raise WAB::Error, 'path can not be empty.' if path.empty?
-        if value.is_a?(::WAB::Data)
+        if value.is_a?(WAB::Data)
           value = value.native
         elsif repair
           value = fix_value(value)
@@ -395,7 +395,7 @@ module WAB
         when Array
           detect_array(item)
         when String
-          element = ::WAB::Impl::Data.detect_string(item)
+          element = WAB::Impl::Data.detect_string(item)
           collection[key] = element unless element == item
         end
       end

--- a/lib/wab/impl/expr.rb
+++ b/lib/wab/impl/expr.rb
@@ -8,7 +8,7 @@ module WAB
       def initialize()
       end
 
-      # Evaluate the expression using the supplied ::WAB::Data object. Each
+      # Evaluate the expression using the supplied WAB::Data object. Each
       # expression subclass evaluates differently.
       #
       # data:: data object to evaluate against.

--- a/lib/wab/impl/handler.rb
+++ b/lib/wab/impl/handler.rb
@@ -5,7 +5,7 @@ module WAB
   module Impl
 
     # Handler for requests that fall under the path assigned to the
-    # Controller. This is used only with the ::WAB::Impl::Shell.
+    # Controller. This is used only with the WAB::Impl::Shell.
     class Handler < WEBrick::HTTPServlet::AbstractServlet
 
       def initialize(server, shell)
@@ -73,7 +73,7 @@ module WAB
 
       # Sends the results from a controller request.
       def send_result(result, res)
-        result = @shell.data(result) unless result.is_a?(::WAB::Data)
+        result = @shell.data(result) unless result.is_a?(WAB::Data)
         res.status = 200
         res['Content-Type'] = 'application/json'
         @shell.logger.debug("Reply: #{result.json}") if @shell.logger.debug?

--- a/lib/wab/impl/model.rb
+++ b/lib/wab/impl/model.rb
@@ -5,7 +5,7 @@ module WAB
   module Impl
 
     # The Model class is used to store data when using the
-    # ::WAB::Impl::Shell. It is no intended for any other use. The *get* and
+    # WAB::Impl::Shell. It is no intended for any other use. The *get* and
     # *query* methods are the primary means of interacting with the model.
     #
     # The Model is simple in that it stores data in a Hash references by *ref*
@@ -25,7 +25,7 @@ module WAB
         load_files unless @dir.nil?
       end
 
-      # Get a single record in the database. A ::WAB::Impl::Data object is
+      # Get a single record in the database. A WAB::Impl::Data object is
       # returned if not nil.
       #
       # ref:: references number of the object to retrieve.
@@ -183,7 +183,7 @@ module WAB
 
       def write_to_file(ref, obj)
         return if @dir.nil?
-        obj.native if obj.is_a?(::WAB::Data)
+        obj.native if obj.is_a?(WAB::Data)
         File.open(File.join(@dir, "%016x.json" % ref), 'wb') { |f| f.write(Oj.dump(obj, mode: :wab, indent: 0)) }
       end
 

--- a/lib/wab/impl/shell.rb
+++ b/lib/wab/impl/shell.rb
@@ -47,7 +47,7 @@ module WAB
       # with the Shell.
       def start()
         server = WEBrick::HTTPServer.new(Port: @http_port, DocumentRoot: @http_dir)
-        server.mount('/v1', ::WAB::Impl::Handler, self)
+        server.mount('/v1', WAB::Impl::Handler, self)
 
         trap 'INT' do server.shutdown end
         server.start
@@ -72,7 +72,7 @@ module WAB
       # data:: data to extract the type from for lookup in the controllers
       def controller(data)
         path = data.get(:path)
-        path = path.native if path.is_a?(::WAB::Data)
+        path = path.native if path.is_a?(WAB::Data)
         return path_controller(path) unless path.nil? || (path.length <= @path_pos)
 
         content = data.get(:content)

--- a/lib/wab/io/engine.rb
+++ b/lib/wab/io/engine.rb
@@ -145,7 +145,7 @@ module WAB
         end
         # If reply_body is nil then it is async.
         unless reply_body.nil?
-          reply_body = reply_body.native if reply_body.is_a?(::WAB::Data)
+          reply_body = reply_body.native if reply_body.is_a?(WAB::Data)
           msg = {rid: rid, api: 2, body: reply_body}
           @shell.info("=> view: #{Oj.dump(msg, mode: :wab)}") if @shell.info?
           $stdout.puts(@shell.data(msg).json)

--- a/lib/wab/io/shell.rb
+++ b/lib/wab/io/shell.rb
@@ -56,7 +56,7 @@ module WAB
       # data:: data to extract the type from for lookup in the controllers
       def controller(data)
         path = data.get(:path)
-        path = path.native if path.is_a?(::WAB::Data)
+        path = path.native if path.is_a?(WAB::Data)
         return path_controller(path) unless path.nil? || (path.length <= @path_pos)
 
         content = data.get(:content)
@@ -84,7 +84,7 @@ module WAB
       # value:: initial value
       # repair:: flag indicating invalid value should be repaired if possible
       def data(value={}, repair=false)
-        ::WAB::Impl::Data.new(value, repair)
+        WAB::Impl::Data.new(value, repair)
       end
 
       ### View related methods.

--- a/lib/wab/uuid.rb
+++ b/lib/wab/uuid.rb
@@ -11,7 +11,7 @@ module WAB
     # following the pattern "123e4567-e89b-12d3-a456-426655440000".
     def initialize(id)
       @id = id.downcase
-      raise ::WAB::ParseError.new('Invalid UUID format.') unless WAB::Utils.uuid_format?(@id)
+      raise WAB::ParseError.new('Invalid UUID format.') unless WAB::Utils.uuid_format?(@id)
     end
 
     # Returns the string representation of the UUID.

--- a/test/bench_io_shell.rb
+++ b/test/bench_io_shell.rb
@@ -21,7 +21,7 @@ if fork.nil? # child
   $stdout = from_w
   from_r.close
 
-  shell = ::WAB::IO::Shell.new(1, 'kind', 0)
+  shell = WAB::IO::Shell.new(1, 'kind', 0)
   shell.timeout = 0.5
   shell.logger.level = Logger::WARN # change to Logger::INFO for debugging
   shell.register_controller(nil, MirrorController.new(shell))
@@ -37,10 +37,10 @@ else
   reply = nil
   start = Time.now
   n.times { |i|
-    to_w.puts(::WAB::Impl::Data.new({rid: 'rid-read-id', api: 1, body: {op: 'GET', path: ['sample', '12345']}}, false).json)
+    to_w.puts(WAB::Impl::Data.new({rid: 'rid-read-id', api: 1, body: {op: 'GET', path: ['sample', '12345']}}, false).json)
     to_w.flush
     Oj.strict_load(from_r, symbol_keys: true) { |msg| reply = msg; break }
-    to_w.puts(::WAB::Impl::Data.new({rid: "#{i+1}", api: 4, body: {code: 0, results:[{kind: 'sample', id: 12345, num: 7}]}}, false).json)
+    to_w.puts(WAB::Impl::Data.new({rid: "#{i+1}", api: 4, body: {code: 0, results:[{kind: 'sample', id: 12345, num: 7}]}}, false).json)
     to_w.flush
     Oj.strict_load(from_r, symbol_keys: true) { |msg| reply = msg; break }
   }

--- a/test/mirror_controller.rb
+++ b/test/mirror_controller.rb
@@ -3,7 +3,7 @@
 
 require 'wab'
 
-class MirrorController < ::WAB::Controller
+class MirrorController < WAB::Controller
   def initialize(shell)
     super(shell)
   end

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -201,7 +201,7 @@ class TestImplData < TestImpl
 
     assert_equal(Time, d.get('t').class)
     assert_equal(::URI::HTTP, d.get('uris.0').class)
-    assert_equal(::WAB::UUID, d.get('sub.uuid').class)
+    assert_equal(WAB::UUID, d.get('sub.uuid').class)
   end
 
 end # TestImplData

--- a/test/test_expr.rb
+++ b/test/test_expr.rb
@@ -27,7 +27,7 @@ class TestExpr < TestImpl
                ['AND', ['HAS', 'str'], ['EQ', 'num', 7]],
               ]
     natives.each { |n|
-      x = ::WAB::Impl::ExprParser.parse(n)
+      x = WAB::Impl::ExprParser.parse(n)
       assert_equal(n, x.native, "parsed failed for #{n}")
     }
   end

--- a/test/test_expr_and.rb
+++ b/test/test_expr_and.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprAnd < TestImpl
 
   def test_and_native
-    x = ::WAB::Impl::And.new(::WAB::Impl::Has.new('num'), ::WAB::Impl::Eq.new('num', 7))
+    x = WAB::Impl::And.new(WAB::Impl::Has.new('num'), WAB::Impl::Eq.new('num', 7))
     assert_equal(['AND', ['HAS', 'num'], ['EQ', 'num', 7]], x.native, 'AND native mismatch')
   end
 
   def test_and
     d = make_sample_data()
-    x = ::WAB::Impl::And.new(::WAB::Impl::Has.new('num'), ::WAB::Impl::Eq.new('num', 7))
+    x = WAB::Impl::And.new(WAB::Impl::Has.new('num'), WAB::Impl::Eq.new('num', 7))
     assert(x.eval(d), 'checking AND match')
 
-    x = ::WAB::Impl::And.new(::WAB::Impl::Has.new('num'), ::WAB::Impl::Eq.new('num', 8))
+    x = WAB::Impl::And.new(WAB::Impl::Has.new('num'), WAB::Impl::Eq.new('num', 8))
     refute(x.eval(d), 'checking AND mismatch')
   end
 

--- a/test/test_expr_between.rb
+++ b/test/test_expr_between.rb
@@ -6,35 +6,35 @@ require_relative 'helper'
 class TestExprBetween < TestImpl
 
   def test_between_native
-    x = ::WAB::Impl::Between.new('num', 3, 7, true, false)
+    x = WAB::Impl::Between.new('num', 3, 7, true, false)
     assert_equal(['BETWEEN', 'num', 3, 7, true, false], x.native, 'BETWEEN native mismatch')
   end
 
   def test_between_int
     d = make_sample_data()
-    x = ::WAB::Impl::Between.new('num', 7, 10)
+    x = WAB::Impl::Between.new('num', 7, 10)
     assert(x.eval(d), 'checking BETWEEN match with an integer arg')
 
-    x = ::WAB::Impl::Between.new('num', 8, 10)
+    x = WAB::Impl::Between.new('num', 8, 10)
     refute(x.eval(d), 'checking BETWEEN mismatch with an integer arg')
 
-    x = ::WAB::Impl::Between.new('num', 5, 7)
+    x = WAB::Impl::Between.new('num', 5, 7)
     assert(x.eval(d), 'checking BETWEEN match with an integer arg')
 
-    x = ::WAB::Impl::Between.new('num', 5, 6)
+    x = WAB::Impl::Between.new('num', 5, 6)
     refute(x.eval(d), 'checking BETWEEN mismatch with an integer arg')
 
     # exclusive of min
-    x = ::WAB::Impl::Between.new('num', 6, 10, false)
+    x = WAB::Impl::Between.new('num', 6, 10, false)
     assert(x.eval(d), 'checking BETWEEN match with an integer arg')
 
-    x = ::WAB::Impl::Between.new('num', 7, 10, false)
+    x = WAB::Impl::Between.new('num', 7, 10, false)
     refute(x.eval(d), 'checking BETWEEN mismatch with an integer arg')
 
-    x = ::WAB::Impl::Between.new('num', 5, 8, false, false)
+    x = WAB::Impl::Between.new('num', 5, 8, false, false)
     assert(x.eval(d), 'checking BETWEEN match with an integer arg')
 
-    x = ::WAB::Impl::Between.new('num', 5, 7, false, false)
+    x = WAB::Impl::Between.new('num', 5, 7, false, false)
     refute(x.eval(d), 'checking BETWEEN mismatch with an integer arg')
 
   end

--- a/test/test_expr_eq.rb
+++ b/test/test_expr_eq.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprEq < TestImpl
 
   def test_eq_native
-    x = ::WAB::Impl::Eq.new('num', 7)
+    x = WAB::Impl::Eq.new('num', 7)
     assert_equal(['EQ', 'num', 7], x.native, 'EQ native mismatch')
   end
 
   def test_eq_int
     d = make_sample_data()
-    x = ::WAB::Impl::Eq.new('num', 7)
+    x = WAB::Impl::Eq.new('num', 7)
     assert(x.eval(d), 'checking EQ match with an integer arg')
 
-    x = ::WAB::Impl::Eq.new('num', 17)
+    x = WAB::Impl::Eq.new('num', 17)
     refute(x.eval(d), 'checking EQ mismatch with an integer arg')
   end
 

--- a/test/test_expr_gt.rb
+++ b/test/test_expr_gt.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprGt < TestImpl
 
   def test_gt_native
-    x = ::WAB::Impl::Gt.new('num', 3)
+    x = WAB::Impl::Gt.new('num', 3)
     assert_equal(['GT', 'num', 3], x.native, 'GT native mismatch')
   end
 
   def test_gt_int
     d = make_sample_data()
-    x = ::WAB::Impl::Gt.new('num', 6)
+    x = WAB::Impl::Gt.new('num', 6)
     assert(x.eval(d), 'checking GT match with an integer arg')
 
-    x = ::WAB::Impl::Gt.new('num', 7)
+    x = WAB::Impl::Gt.new('num', 7)
     refute(x.eval(d), 'checking GT mismatch with an integer arg')
   end
 

--- a/test/test_expr_gte.rb
+++ b/test/test_expr_gte.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprGte < TestImpl
 
   def test_gte_native
-    x = ::WAB::Impl::Gte.new('num', 3)
+    x = WAB::Impl::Gte.new('num', 3)
     assert_equal(['GTE', 'num', 3], x.native, 'GTE native mismatch')
   end
 
   def test_gte_int
     d = make_sample_data()
-    x = ::WAB::Impl::Gte.new('num', 7)
+    x = WAB::Impl::Gte.new('num', 7)
     assert(x.eval(d), 'checking GTE match with an integer arg')
 
-    x = ::WAB::Impl::Gte.new('num', 8)
+    x = WAB::Impl::Gte.new('num', 8)
     refute(x.eval(d), 'checking GTE mismatch with an integer arg')
   end
 

--- a/test/test_expr_has.rb
+++ b/test/test_expr_has.rb
@@ -7,10 +7,10 @@ class TestExprHas < TestImpl
 
   def test_has_int
     d = make_sample_data()
-    x = ::WAB::Impl::Has.new('num')
+    x = WAB::Impl::Has.new('num')
     assert(x.eval(d), 'checking HAS match')
 
-    x = ::WAB::Impl::Has.new('none')
+    x = WAB::Impl::Has.new('none')
     refute(x.eval(d), 'checking HAS mismatch')
   end
 

--- a/test/test_expr_in.rb
+++ b/test/test_expr_in.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprIn < TestImpl
 
   def test_in_native
-    x = ::WAB::Impl::In.new('num', 3, 4, 5)
+    x = WAB::Impl::In.new('num', 3, 4, 5)
     assert_equal(['IN', 'num', 3, 4, 5], x.native, 'IN native mismatch')
   end
 
   def test_in_int
     d = make_sample_data()
-    x = ::WAB::Impl::In.new('num', 1, 3, 5, 7, 11)
+    x = WAB::Impl::In.new('num', 1, 3, 5, 7, 11)
     assert(x.eval(d), 'checking IN match with an integer arg')
 
-    x = ::WAB::Impl::In.new('num', 0, 2, 4, 6, 8, 10)
+    x = WAB::Impl::In.new('num', 0, 2, 4, 6, 8, 10)
     refute(x.eval(d), 'checking IN mismatch with an integer arg')
   end
 

--- a/test/test_expr_lt.rb
+++ b/test/test_expr_lt.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprLt < TestImpl
 
   def test_lt_native
-    x = ::WAB::Impl::Lt.new('num', 3)
+    x = WAB::Impl::Lt.new('num', 3)
     assert_equal(['LT', 'num', 3], x.native, 'LT native mismatch')
   end
 
   def test_lt_int
     d = make_sample_data()
-    x = ::WAB::Impl::Lt.new('num', 8)
+    x = WAB::Impl::Lt.new('num', 8)
     assert(x.eval(d), 'checking LT match with an integer arg')
 
-    x = ::WAB::Impl::Lt.new('num', 7)
+    x = WAB::Impl::Lt.new('num', 7)
     refute(x.eval(d), 'checking LT mismatch with an integer arg')
   end
 

--- a/test/test_expr_lte.rb
+++ b/test/test_expr_lte.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprLte < TestImpl
 
   def test_lte_native
-    x = ::WAB::Impl::Lte.new('num', 3)
+    x = WAB::Impl::Lte.new('num', 3)
     assert_equal(['LTE', 'num', 3], x.native, 'LTE native mismatch')
   end
 
   def test_lte_int
     d = make_sample_data()
-    x = ::WAB::Impl::Lte.new('num', 7)
+    x = WAB::Impl::Lte.new('num', 7)
     assert(x.eval(d), 'checking LTE match with an integer arg')
 
-    x = ::WAB::Impl::Lte.new('num', 6)
+    x = WAB::Impl::Lte.new('num', 6)
     refute(x.eval(d), 'checking LTE mismatch with an integer arg')
   end
 

--- a/test/test_expr_not.rb
+++ b/test/test_expr_not.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprNot < TestImpl
 
   def test_not_native
-    x = ::WAB::Impl::Not.new(::WAB::Impl::Eq.new('num', 7))
+    x = WAB::Impl::Not.new(WAB::Impl::Eq.new('num', 7))
     assert_equal(['NOT', ['EQ', 'num', 7]], x.native, 'NOT native mismatch')
   end
 
   def test_not
     d = make_sample_data()
-    x = ::WAB::Impl::Not.new(::WAB::Impl::Eq.new('num', 8))
+    x = WAB::Impl::Not.new(WAB::Impl::Eq.new('num', 8))
     assert(x.eval(d), 'checking NOT match')
 
-    x = ::WAB::Impl::Not.new(::WAB::Impl::Eq.new('num', 7))
+    x = WAB::Impl::Not.new(WAB::Impl::Eq.new('num', 7))
     refute(x.eval(d), 'checking NOT mismatch')
   end
 

--- a/test/test_expr_or.rb
+++ b/test/test_expr_or.rb
@@ -6,16 +6,16 @@ require_relative 'helper'
 class TestExprOr < TestImpl
 
   def test_or_native
-    x = ::WAB::Impl::Or.new(::WAB::Impl::Has.new('num'), ::WAB::Impl::Eq.new('num', 7))
+    x = WAB::Impl::Or.new(WAB::Impl::Has.new('num'), WAB::Impl::Eq.new('num', 7))
     assert_equal(['OR', ['HAS', 'num'], ['EQ', 'num', 7]], x.native, 'OR native mismatch')
   end
 
   def test_or
     d = make_sample_data()
-    x = ::WAB::Impl::Or.new(::WAB::Impl::Has.new('str'), ::WAB::Impl::Eq.new('num', 8))
+    x = WAB::Impl::Or.new(WAB::Impl::Has.new('str'), WAB::Impl::Eq.new('num', 8))
     assert(x.eval(d), 'checking OR match')
 
-    x = ::WAB::Impl::Or.new(::WAB::Impl::Has.new('none'), ::WAB::Impl::Eq.new('num', 8))
+    x = WAB::Impl::Or.new(WAB::Impl::Has.new('none'), WAB::Impl::Eq.new('num', 8))
     refute(x.eval(d), 'checking OR mismatch')
   end
 

--- a/test/test_expr_regex.rb
+++ b/test/test_expr_regex.rb
@@ -9,19 +9,19 @@ require 'wab/impl'
 class TestExprRegex < TestImpl
 
   def test_regex_native
-    x = ::WAB::Impl::Regex.new('str', '^a *.')
+    x = WAB::Impl::Regex.new('str', '^a *.')
     assert_equal(['REGEX', 'str', '^a *.'], x.native, 'REGEX native mismatch')
   end
 
   def test_regex_int
     d = make_sample_data()
-    x = ::WAB::Impl::Regex.new('str', '^a .*')
+    x = WAB::Impl::Regex.new('str', '^a .*')
     assert(x.eval(d), 'checking REGEX match with string arg')
 
-    x = ::WAB::Impl::Regex.new('str', '^x .*')
+    x = WAB::Impl::Regex.new('str', '^x .*')
     refute(x.eval(d), 'checking REGEX mismatch with string arg')
 
-    x = ::WAB::Impl::Regex.new('num', 8)
+    x = WAB::Impl::Regex.new('num', 8)
     refute(x.eval(d), 'checking REGEX mismatch with an integer arg')
   end
 

--- a/test/test_impl.rb
+++ b/test/test_impl.rb
@@ -8,7 +8,7 @@ require 'wab/impl'
 class TestImpl < Minitest::Test
 
   def setup
-    @shell = ::WAB::Impl::Shell.new({})
+    @shell = WAB::Impl::Shell.new({})
   end
 
   def make_sample_data()
@@ -21,7 +21,7 @@ class TestImpl < Minitest::Test
                   t: Time.gm(2017, 1, 5, 15, 4, 33.123456789),
                   big: BigDecimal('63.21'),
                   uri: URI('http://opo.technology/sample'),
-                  uuid: ::WAB::UUID.new('b0ca922d-372e-41f4-8fea-47d880188ba3'),
+                  uuid: WAB::UUID.new('b0ca922d-372e-41f4-8fea-47d880188ba3'),
                   a: [],
                   h: {},
                 })

--- a/test/test_io_shell.rb
+++ b/test/test_io_shell.rb
@@ -140,7 +140,7 @@ class TestIoShell < Minitest::Test
       $stdout = from_w
       from_r.close
 
-      shell = ::WAB::IO::Shell.new(2, 'kind', 0)
+      shell = WAB::IO::Shell.new(2, 'kind', 0)
       shell.timeout = 0.5
       shell.logger.level = Logger::WARN # change to Logger::INFO for debugging
       shell.register_controller(nil, MirrorController.new(shell))
@@ -155,7 +155,7 @@ class TestIoShell < Minitest::Test
       # desired.
       script.each { |pair|
         unless pair[0].nil?
-          to_w.puts(::WAB::Impl::Data.new(pair[0], false).json)
+          to_w.puts(WAB::Impl::Data.new(pair[0], false).json)
           to_w.flush
         end
 
@@ -179,7 +179,7 @@ class TestIoShell < Minitest::Test
       # fail. Thats okay as the write is only to tell the child to shutdown
       # and it already has.
       begin
-        to_w.puts(::WAB::Impl::Data.new({ api: -2 }, false).json)
+        to_w.puts(WAB::Impl::Data.new({ api: -2 }, false).json)
         to_w.flush
       rescue Exception
       end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -9,7 +9,7 @@ class TestModel < TestImpl
 
   def test_model_create
     # nil arg indicates don't save to disk
-    model = ::WAB::Impl::Model.new(nil)
+    model = WAB::Impl::Model.new(nil)
     tql = {
       rid: 12345,
       insert: {


### PR DESCRIPTION
Purely a matter of personal preference.
Since the classes in `lib/` are already namespaced under the top-level `WAB` module, **IMO**, the trailing `::` can be ommitted. Though I agree on its use in a module that would encapsulate `WAB` itself
```ruby
module Foo
  module WAB
    class FooController < ::WAB::Controller
    [...]
    end
  end
end
```