### PR TITLE
convert static instance variables into local variables

### DIFF
--- a/lib/wab/io/engine.rb
+++ b/lib/wab/io/engine.rb
@@ -13,6 +13,7 @@ module WAB
       # tcnt:: processing thread count
       def initialize(shell, tcnt)
         @shell = shell
+        @last_rid = 0
         @pending = {}
         @lock = Thread::Mutex.new
         @queue = Queue.new
@@ -77,11 +78,10 @@ module WAB
       # tql:: the body of the message which should be JSON-TQL as a native Hash
       def request(tql, timeout)
         call = Call.new(timeout)
-        last_rid = 0
 
         @lock.synchronize {
-          last_rid += 1
-          call.rid = last_rid.to_s
+          @last_rid += 1
+          call.rid = @last_rid.to_s
           @pending[call.rid] = call
         }
 

--- a/lib/wab/io/engine.rb
+++ b/lib/wab/io/engine.rb
@@ -13,19 +13,18 @@ module WAB
       # tcnt:: processing thread count
       def initialize(shell, tcnt)
         @shell = shell
-        @last_rid = 0
         @pending = {}
         @lock = Thread::Mutex.new
         @queue = Queue.new
         tcnt = 1 if 0 >= tcnt
         @tcnt = tcnt
         @timeout_thread = nil
-        @proc_threads = []
       end
 
       def start()
+        proc_threads = []
         @tcnt.times {
-          @proc_threads << Thread.new {
+          proc_threads << Thread.new {
             while true
               begin
                 break unless process_msg(@queue.pop)
@@ -58,7 +57,7 @@ module WAB
             break
           when -9
             Thread.kill(@timeout_thread)
-            @proc_threads.each { |t| Thread.kill(t) }
+            proc_threads.each { |t| Thread.kill(t) }
             Process.exit(0)
           else
             $stderr.puts "*-*-* Invalid api value (#{api}) in message."
@@ -78,11 +77,14 @@ module WAB
       # tql:: the body of the message which should be JSON-TQL as a native Hash
       def request(tql, timeout)
         call = Call.new(timeout)
+        last_rid = 0
+
         @lock.synchronize {
-          @last_rid += 1
-          call.rid = @last_rid.to_s
+          last_rid += 1
+          call.rid = last_rid.to_s
           @pending[call.rid] = call
         }
+
         msg = {rid: call.rid, api: 3, body: tql}
         @shell.info("=> model: #{Oj.dump(msg, mode: :wab)}") if @shell.info?
         data = @shell.data(msg, true)


### PR DESCRIPTION
~~`@last_rid` and~~ `@proc_threads` in `IO::Engine` is initialized with static values, do not have associated setter_method or an `attr_writer` or `attr_accessor` and is used only in one method function.

So, it can be converted into a local variable for the associated method function

---
`@last_rid` gets updated by `:synchronize` block