### PR TITLE
Sketch out possible directory layout for a WAB App

### DIFF
--- a/pages/App-specification.md
+++ b/pages/App-specification.md
@@ -3,22 +3,23 @@
 
 ```sh
 ./app-name
-├───assets                      # Front-end directory linked from within *./index.html*
-|   ├─── css
-|   |    └─── wab.css           # App stylesheet
-|   ├─── fonts
-|   |    └─── wabfont
-|   └─── js
-|        ├─── foo.es6           # ES6 Module component
-|        ├─── bar.es6           # ES6 Module component
-|        ├─── wab.es6           # Base ES6 Module that *imports* every other module components
-|        └─── wab.js            # ES5 Javascript for old browsers
-├─── config                     # Place for all App config files, including JSON and YAML files
+├───site
+|   ├───assets                      # Front-end directory linked from within *./index.html*
+|   |   ├─── css
+|   |   |    └─── wab.css           # App stylesheet
+|   |   ├─── fonts
+|   |   |    └─── wabfont
+|   |   └─── js
+|   |        ├─── foo.es6           # ES6 Module component
+|   |        ├─── bar.es6           # ES6 Module component
+|   |        ├─── wab.es6           # Base ES6 Module that *imports* every other module components
+|   |        └─── wab.js            # ES5 Javascript for old browsers
+|   └─── index.html                 # The base HTML file accessed at server root.
+├─── config                         # Place for all App config files, including JSON and YAML files
 |    └─── wab.conf
-├─── controllers                # Place for all controllers in App.
-|    ├─── sample_controller.rb
-|    └─── foo_controller.rb
-└─── index.html                 # The base HTML file accessed at server root.
+└─── lib                            # Place for all controllers in App.
+     ├─── sample_controller.rb
+     └─── foo_controller.rb
 ```
 
 ```html

--- a/pages/App-specification.md
+++ b/pages/App-specification.md
@@ -1,0 +1,38 @@
+## Single-page App Specification
+
+
+```sh
+./app-name
+├───assets                      # Front-end directory linked from within *./index.html*
+|   ├─── css
+|   |    └─── wab.css           # App stylesheet
+|   ├─── fonts
+|   |    └─── wabfont
+|   └─── js
+|        ├─── js-next
+|        |    ├─── foo.js       # ES6 Module component
+|        |    ├─── bar.js       # ES6 Module component
+|        |    └─── wab.js       # Base ES6 Module that *imports* every other module components
+|        └─── wab.js            # ES5 Javascript for old browsers
+├─── configs                    # Place for all App config files, including JSON and YAML files
+|    └─── wab.conf
+├─── controllers                # Place for all controllers in App.
+|    ├─── sample_controller.rb
+|    └─── foo_controller.rb
+└─── index.html                 # The base HTML file accessed at server root.
+```
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>App Title</title>
+    <link rel="stylesheet" href="assets/css/wab.css" />
+  </head>
+  <body>
+    <script type="module" src="assets/js/js-next/wab.js"></script>
+    <script nomodule src="assets/js/wab.js"></script>
+  </body>
+</html>
+```

--- a/pages/App-specification.md
+++ b/pages/App-specification.md
@@ -9,12 +9,11 @@
 |   ├─── fonts
 |   |    └─── wabfont
 |   └─── js
-|        ├─── js-next
-|        |    ├─── foo.js       # ES6 Module component
-|        |    ├─── bar.js       # ES6 Module component
-|        |    └─── wab.js       # Base ES6 Module that *imports* every other module components
+|        ├─── foo.es6           # ES6 Module component
+|        ├─── bar.es6           # ES6 Module component
+|        ├─── wab.es6           # Base ES6 Module that *imports* every other module components
 |        └─── wab.js            # ES5 Javascript for old browsers
-├─── configs                    # Place for all App config files, including JSON and YAML files
+├─── config                     # Place for all App config files, including JSON and YAML files
 |    └─── wab.conf
 ├─── controllers                # Place for all controllers in App.
 |    ├─── sample_controller.rb
@@ -31,7 +30,7 @@
     <link rel="stylesheet" href="assets/css/wab.css" />
   </head>
   <body>
-    <script type="module" src="assets/js/js-next/wab.js"></script>
+    <script type="module" src="assets/js/wab.es6"></script>
     <script nomodule src="assets/js/wab.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Outlining a possible layout for a WAB app..
This PR will serve as documentation for the genesis of the future App structure.

### Back-end

Of the directories listed, two directories `controllers` and `configs` are of vital importance to WAB. Their contents form the "heart" of the App.
If `controllers` is empty, WAB falls back to `OpenController` **unless** a controller key is defined in the config file.
The `configs` directory can contain either a `*.conf` file, or a JSON file or a YAML file. If no config file is passed via the terminal, then WAB looks for a `./configs/wab.conf` >`./configs/wab.json` > `configs/wab.yml` in that order.

### Front-end

The `assets` dir is where the "front-end" of the App is located. It can be named anything, its sub-directories can be named anything. Just that the contents should be linked to the `./index.html` as appropriate.

WAB doesn't compile Sass out-of-the-box (yet). `css` houses the stylesheet(s).
WAB doesn't compile CoffeeScript or other JS preprocessors. `js` houses the vanilla JS. In the sample-app, ES2015 (or ES6) JS code is housed in subdirectory `js-next` with corresponding ES5 or current-widespread flavor at the root of `js` as a fallback for older browsers.