### PR TITLE
Refine `Impl::Init` class and associates

### DIFF
--- a/bin/wabur
+++ b/bin/wabur
@@ -35,14 +35,14 @@ URL path to be handled.
 
 Modes (the first non-option) available are:
 
-  run: Runs a wabur as a runner and shell. Also the default. Any types
-       specified will be ignored.
+   run: Runs wabur as a runner and shell. Also the default. Any types
+        specified will be ignored.
 
-  new: New project directory created and set up. The --base options must be
-       provided to specify the directory to create and initialize. Not
-       providing a base will revert to the init mode.
+   new: New project directory created and set up. The `--base` options must be
+        provided to specify the directory to create and initialize. Not
+        providing the `--base` switch will revert to the `init` mode.
 
-  init - Initialize a project when called from the project directory.
+  init: Initialize a project into the current directory.
 
 }
 
@@ -111,7 +111,7 @@ config = WAB::Impl::Configuration.new(usage, options)
 if 'new' == config[:mode]
   dir = config[:base] || '.'
   dir = File.expand_path(dir)
-  FileUtils.mkdir_p(dir) unless File.expand_path(',') == dir
+  FileUtils.mkdir_p(dir) unless File.expand_path('.') == dir
   WAB::Impl::Init.setup(File.expand_path(dir), config)
 elsif 'init' == config[:mode]
   WAB::Impl::Init.setup(File.expand_path('.'), config)
@@ -126,4 +126,3 @@ else
   # Start a shell initialized with the final configuration.
   WAB::Impl::Shell.new(config).start
 end
-

--- a/bin/wabur
+++ b/bin/wabur
@@ -42,7 +42,11 @@ Modes (the first non-option) available are:
         provided to specify the directory to create and initialize. Not
         providing the `--base` switch will revert to the `init` mode.
 
+          e.g.: wabur new Entry Article --base my_app
+
   init: Initialize a project into the current directory.
+
+          e.g.: wabur init Entry Article
 
 }
 

--- a/lib/wab/impl/init.rb
+++ b/lib/wab/impl/init.rb
@@ -15,13 +15,12 @@ module WAB
       class << self
         def setup(path, config)
           exist_check(path)
-          types = config[:rest]
 
+          types      = config[:rest]
           config_dir = "#{path}/config"
-          FileUtils.mkdir_p(config_dir)
+          lib_dir    = "#{path}/lib"
 
-          lib_dir = "#{path}/lib"
-          FileUtils.mkdir_p(lib_dir)
+          FileUtils.mkdir_p([config_dir,lib_dir])
 
           write_ui_controllers(lib_dir, types)
           write_spawn(lib_dir, types)
@@ -33,6 +32,8 @@ module WAB
         rescue StandardError => e
           puts "*-*-* #{e.class}: #{e.message}"
         end
+
+        private
 
         def exist_check(path)
           [
@@ -47,71 +48,56 @@ module WAB
         end
         
         def write_ui_controllers(dir, types)
-          template = File.open("#{__dir__}/templates/ui_controller.rb.template") { |f| f.read }
-          File.open("#{dir}/ui_controller.rb", 'w') { |f|
-            rest_flows = ''
-            types.each { |type|
-              rest_flows << %|
-    add_flow(WAB::UI::RestFlow.new(shell,
-                                   {
-                                     kind: '#{type}',
-                                   }, ['$ref']))
-|
-            }
-            f.write(template % { rest_flows: rest_flows })
+          rest_flows = ''
+          types.each { |type|
+            rest_flows << %|
+    add_flow(UI::RestFlow.new(shell, { kind: '#{type}'}, ['$ref']))|
           }
+          write_file(dir, 'ui_controller.rb', { rest_flows: rest_flows })
         end
         
         def write_spawn(dir, types)
-          template = File.open("#{__dir__}/templates/spawn.rb.template") { |f| f.read }
-          File.open("#{dir}/spawn.rb", 'w') { |f|
-            controllers = ''
-            types.each { |type|
-              controllers << %|
+          controllers = ''
+          types.each { |type|
+            controllers << %|
 shell.register_controller('#{type}', WAB::OpenController.new(shell))|
-            }
-            f.write(template.gsub('%{controllers}', controllers))
           }
+          write_file(dir, 'spawn.rb', { controllers: controllers })
         end
 
         def write_wabur_conf(dir, types)
-          template = File.open("#{__dir__}/templates/wabur.conf.template") { |f| f.read }
-          File.open("#{dir}/wabur.conf", 'w') { |f|
-            handlers = ''
-            types.each_index { |index|
-              handlers << %|
+          handlers = ''
+          types.each_index { |index|
+            handlers << %|
 handler.#{index + 1}.type = #{types[index]}
-handler.#{index + 1}.handler = WAB::OpenController
-|
-            }
-            f.write(template % { handlers: handlers })
+handler.#{index + 1}.handler = WAB::OpenController|
           }
+          write_file(dir, 'wabur.conf', { handlers: handlers })
         end
         
-        def write_opo_conf(dir, types)
-          template = File.open("#{__dir__}/templates/opo.conf.template") { |f| f.read }
-          File.open("#{dir}/opo.conf", 'w') { |f|
-            f.write(template)
-          }
+        def write_opo_conf(dir, _types)
+          write_file(dir, 'opo.conf')
         end
         
         def write_opo_rub_conf(dir, types)
-          template = File.open("#{__dir__}/templates/opo-rub.conf.template") { |f| f.read }
-          File.open("#{dir}/opo-rub.conf", 'w') { |f|
-            handlers = ''
-            types.each_index { |index|
-              type = types[index]
-              handlers << %|
+          handlers = ''
+          types.each_index { |index|
+            type = types[index]
+            handlers << %|
 handler.#{type.downcase}.path = /v1/#{type}/**
 handler.#{type.downcase}.class = WAB::OpenController
 |
-            }
-            f.write(template % { handlers: handlers })
           }
+          write_file(dir, 'opo-rub.conf', { handlers: handlers })
+        end
+
+        def write_file(dir, filename, gsub_data=nil)
+          template = File.open("#{__dir__}/templates/#{filename}.template", 'rb') { |f| f.read }
+          content  = gsub_data.nil? ? template : template % gsub_data
+          File.open("#{dir}/#{filename}", 'wb') { |f| f.write(content) }
         end
 
       end # self
     end # Init
   end # Impl
 end # WAB
-      

--- a/lib/wab/impl/init.rb
+++ b/lib/wab/impl/init.rb
@@ -51,7 +51,15 @@ module WAB
           rest_flows = ''
           types.each { |type|
             rest_flows << %|
-    add_flow(UI::RestFlow.new(shell, { kind: '#{type}'}, ['$ref']))|
+    add_flow(
+      WAB::UI::RestFlow.new(
+        shell,
+        {
+          kind: '#{type}',
+        },
+        ['$ref']
+      )
+    )|
           }
           write_file(dir, 'ui_controller.rb', { rest_flows: rest_flows })
         end

--- a/lib/wab/impl/templates/opo.conf.template
+++ b/lib/wab/impl/templates/opo.conf.template
@@ -14,10 +14,10 @@ dir = opo/data
 journal = false
 
 # If sync is true then writes are always synced to disk before
-# returning. Performance is far better is sync is set to false.
+# returning. Performance is far better if sync is set to false.
 sync = false
 
-# If exit_sync is true then writes are performed on normall shutdown or by
+# If exit_sync is true then writes are performed on normal shutdown or by
 # ctrl-C unless journalling is already on or sync is true.
 exit_sync = true
 

--- a/lib/wab/impl/templates/spawn.rb.template
+++ b/lib/wab/impl/templates/spawn.rb.template
@@ -12,7 +12,6 @@ end
 require 'optparse'
 require 'wab'
 require 'wab/io'
-require 'sample_controller'
 
 # This app is expected to be spawned from a WAB runner. This demonstrates one
 # possible mode for running WAB applications. It is the least performant of
@@ -20,11 +19,11 @@ require 'sample_controller'
 
 $verbose = false
 $thread_count = 1
-$opts = OptionParser.new(%|Usage: sample [options]
+$opts = OptionParser.new("Usage: sample [options]
 
 Acts as a remote Controller in a WAB deployment. Input is from stdin and output
 is on stdout. If verbosity is turned on it is sent to stderr.
-|)
+")
 $opts.on('-v', 'verbose output on stderr')                         { $verbose = true }
 $opts.on('-t', '--thread-count Integer', Integer, 'thread count')  { |t| $thread_count = t }
 $opts.on('-h', '--help', 'show this page')                         { $stderr.puts $opts.help; Process.exit!(0) }
@@ -34,8 +33,7 @@ $opts.parse(ARGV)
 shell = WAB::IO::Shell.new($thread_count, 'kind', 1)
 shell.logger.level = Logger::INFO if $verbose
 
-shell.register_controller('ui', UIController.new(shell))
-%{controllers}
+shell.register_controller('ui', UIController.new(shell))%{controllers}
 
 begin
   shell.start


### PR DESCRIPTION
- mark some methods in `Impl::Init` as `private`
- abstract repeating steps to another helper method
- fix a couple of typos and formatting
- slightly improve `help` display for `wabur` usage