### PR TITLE
Use === in lieu of !(regex).match.nil?

### DIFF
--- a/lib/wab/controller.rb
+++ b/lib/wab/controller.rb
@@ -232,9 +232,9 @@ module WAB
       # ok as is
       return value if !value.empty? && value.start_with?("'")
 
-      if !/^-?\d+$/.match(value).nil?
+      if /^-?\d+$/ === value
         value.to_i
-      elsif !/^-?\d*\.?\d+([eE][-+]?\d+)?$/.match(value).nil?
+      elsif /^-?\d*\.?\d+([eE][-+]?\d+)?$/ === value
         value.to_f
       elsif WAB::Utils.uuid_format?(value)
         WAB::UUID.new(value)

--- a/lib/wab/impl/exprs/regex.rb
+++ b/lib/wab/impl/exprs/regex.rb
@@ -15,7 +15,7 @@ module WAB
 
       def eval(data)
         value = data.get(@path)
-        return !@rx.match(value).nil? if value.is_a?(String)
+        return @rx === value if value.is_a?(String)
         false
       end
 

--- a/lib/wab/utils.rb
+++ b/lib/wab/utils.rb
@@ -1,8 +1,8 @@
 module WAB
   module Utils
     class << self
-      UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-      TIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{9}Z$/
+      UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.freeze
+      TIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{9}Z$/.freeze
 
       def ruby_series
         RbConfig::CONFIG.values_at('MAJOR', 'MINOR').join.to_i
@@ -22,14 +22,14 @@ module WAB
       # "123e4567-e89b-12d3-a456-426655440000"
       def uuid_format?(str)
         return false unless 36 == str.length
-        !UUID_REGEX.match(str).nil?
+        UUID_REGEX === str
       end
 
       # Detect if given string matches a Time format as encoded by WAB components:
       # "2017-09-01T12:45:15.123456789Z"
       def wab_time_format?(str)
         return false unless 30 == str.length
-        !TIME_REGEX.match(str).nil?
+        TIME_REGEX === str
       end
     end
   end


### PR DESCRIPTION
I think it is a lot cleaner this way.., though not sure about its effect on performance.
But in theory it should be an improvement, since it replaces negation and chaining `match` with a nil-check 