### PR TITLE
Define attr_readers for Expr subclasses

### DIFF
--- a/lib/wab/impl/bool_expr.rb
+++ b/lib/wab/impl/bool_expr.rb
@@ -20,6 +20,9 @@ module WAB
         false
       end
 
+      private
+      attr_reader :args
+
     end # BoolExpr
   end # Impl
 end # WAB

--- a/lib/wab/impl/exprs/and.rb
+++ b/lib/wab/impl/exprs/and.rb
@@ -9,19 +9,20 @@ module WAB
       # instances of subclasses of the Expr class.
       #
       # args:: argument to the AND expression
-      def initialize(*args)
-        super
-      end
+      #
+      # def initialize(*args)
+      #   super
+      # end
 
       def eval(data)
-        @args.each { |a|
+        args.each { |a|
           return false unless a.eval(data)
         }
         true
       end
 
       def native()
-        @args.map(&:native).unshift('AND')
+        args.map(&:native).unshift('AND')
       end
 
     end # And

--- a/lib/wab/impl/exprs/between.rb
+++ b/lib/wab/impl/exprs/between.rb
@@ -26,14 +26,14 @@ module WAB
       end
 
       def eval(data)
-        value = data.get(@path)
+        value = data.get(path)
         return false if (@min_incl ? value < @min : value <= @min)
         return false if (@max_incl ? @max < value : @max <= value)
         true
       end
 
       def native()
-        ['BETWEEN', @path, @min, @max, @min_incl, @max_incl]
+        ['BETWEEN', path, @min, @max, @min_incl, @max_incl]
       end
 
     end # Between

--- a/lib/wab/impl/exprs/eq.rb
+++ b/lib/wab/impl/exprs/eq.rb
@@ -16,11 +16,11 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) == @value
+        data.get(path) == @value
       end
 
       def native()
-        ['EQ', @path, @value]
+        ['EQ', path, @value]
       end
 
     end # Eq

--- a/lib/wab/impl/exprs/gt.rb
+++ b/lib/wab/impl/exprs/gt.rb
@@ -18,11 +18,11 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) > @value
+        data.get(path) > @value
       end
 
       def native()
-        ['GT', @path, @value]
+        ['GT', path, @value]
       end
 
     end # Gt

--- a/lib/wab/impl/exprs/gte.rb
+++ b/lib/wab/impl/exprs/gte.rb
@@ -18,11 +18,11 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) >= @value
+        data.get(path) >= @value
       end
 
       def native()
-        ['GTE', @path, @value]
+        ['GTE', path, @value]
       end
 
     end # Gte

--- a/lib/wab/impl/exprs/has.rb
+++ b/lib/wab/impl/exprs/has.rb
@@ -14,11 +14,11 @@ module WAB
       end
 
       def eval(data)
-        data.has?(@path)
+        data.has?(path)
       end
 
       def native()
-        ['HAS', @path]
+        ['HAS', path]
       end
 
     end # Has

--- a/lib/wab/impl/exprs/in.rb
+++ b/lib/wab/impl/exprs/in.rb
@@ -16,11 +16,11 @@ module WAB
       end
 
       def eval(data)
-        @values.include?(data.get(@path))
+        @values.include?(data.get(path))
       end
 
       def native()
-        ['IN', @path].concat(@values)
+        ['IN', path].concat(@values)
       end
 
     end # In

--- a/lib/wab/impl/exprs/lt.rb
+++ b/lib/wab/impl/exprs/lt.rb
@@ -18,11 +18,11 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) < @value
+        data.get(path) < @value
       end
 
       def native()
-        ['LT', @path, @value]
+        ['LT', path, @value]
       end
 
     end # Lt

--- a/lib/wab/impl/exprs/lte.rb
+++ b/lib/wab/impl/exprs/lte.rb
@@ -18,11 +18,11 @@ module WAB
       end
 
       def eval(data)
-        data.get(@path) <= @value
+        data.get(path) <= @value
       end
 
       def native()
-        ['LTE', @path, @value]
+        ['LTE', path, @value]
       end
 
     end # Lte

--- a/lib/wab/impl/exprs/or.rb
+++ b/lib/wab/impl/exprs/or.rb
@@ -9,19 +9,20 @@ module WAB
       # instances of subclasses of the Expr class.
       #
       # args:: argument to the OR expression
-      def initialize(*args)
-        super
-      end
+      #
+      # def initialize(*args)
+      #   super
+      # end
 
       def eval(data)
-        @args.each { |a|
+        args.each { |a|
           return true if a.eval(data)
         }
         false
       end
 
       def native()
-        @args.map(&:native).unshift('OR')
+        args.map(&:native).unshift('OR')
       end
 
     end # Or

--- a/lib/wab/impl/exprs/regex.rb
+++ b/lib/wab/impl/exprs/regex.rb
@@ -14,13 +14,13 @@ module WAB
       end
 
       def eval(data)
-        value = data.get(@path)
+        value = data.get(path)
         return @rx === value if value.is_a?(String)
         false
       end
 
       def native()
-        ['REGEX', @path, @rx.source]
+        ['REGEX', path, @rx.source]
       end
 
     end # Regex

--- a/lib/wab/impl/path_expr.rb
+++ b/lib/wab/impl/path_expr.rb
@@ -9,6 +9,9 @@ module WAB
         @path = path
       end
 
+      private
+      attr_reader :path
+
     end # PathExpr
   end # Impl
 end # WAB


### PR DESCRIPTION
Preserve encapsulation by defining `attr_reader` for `Impl::Expr` subclasses
ref: https://github.com/troessner/reek/blob/v4.7.2/docs/Instance-Variable-Assumption.md

Similar pattern was detected in `UI::` classes as well. But deferring as they require better tests 