### PR TITLE
Set `repair` parameter for Impl::Data.new to `false` by default

### DIFF
--- a/lib/wab/impl/data.rb
+++ b/lib/wab/impl/data.rb
@@ -6,7 +6,7 @@ require 'oj'
 module WAB
   module Impl
 
-    # The class representing the cananical data structure in WAB. Typically
+    # The class representing the canonical data structure in WAB. Typically
     # the Data instances are factory created by the Shell and will most likely
     # not be instance of this class but rather a class that is a duck-type of
     # this class (has the same methods and behavior).
@@ -43,7 +43,7 @@ module WAB
       #
       # value:: initial value
       # repair:: flag indicating invalid value should be repaired if possible
-      def initialize(value, repair, check=true)
+      def initialize(value, repair=false, check=true)
         if repair
           value = fix(value)
         elsif check
@@ -137,7 +137,7 @@ module WAB
       # Make a deep copy of the Data instance.
       def deep_dup()
         # avoid validation by using a empty Hash for the intial value.
-        c = self.class.new({}, false)
+        c = Data.new({})
         c.instance_variable_set(:@root, deep_dup_value(@root))
         c
       end
@@ -315,7 +315,7 @@ module WAB
         when Array
           detect_array(item)
         when String
-          element = WAB::Impl::Data.detect_string(item)
+          element = Data.detect_string(item)
           collection[key] = element unless element == item
         end
       end

--- a/lib/wab/impl/handler.rb
+++ b/lib/wab/impl/handler.rb
@@ -65,8 +65,9 @@ module WAB
         if request_body.nil?
           body = nil
         else
-          body = Oj.strict_load(request_body, symbol_keys: true)
-          body = Data.new(body, false)
+          body = Data.new(
+            Oj.strict_load(request_body, symbol_keys: true)
+          )
           body.detect
         end
         [@shell.path_controller(path), path, query, body]

--- a/test/bench_io_shell.rb
+++ b/test/bench_io_shell.rb
@@ -37,10 +37,10 @@ else
   reply = nil
   start = Time.now
   n.times { |i|
-    to_w.puts(WAB::Impl::Data.new({rid: 'rid-read-id', api: 1, body: {op: 'GET', path: ['sample', '12345']}}, false).json)
+    to_w.puts(WAB::Impl::Data.new({rid: 'rid-read-id', api: 1, body: {op: 'GET', path: ['sample', '12345']}}).json)
     to_w.flush
     Oj.strict_load(from_r, symbol_keys: true) { |msg| reply = msg; break }
-    to_w.puts(WAB::Impl::Data.new({rid: "#{i+1}", api: 4, body: {code: 0, results:[{kind: 'sample', id: 12345, num: 7}]}}, false).json)
+    to_w.puts(WAB::Impl::Data.new({rid: "#{i+1}", api: 4, body: {code: 0, results:[{kind: 'sample', id: 12345, num: 7}]}}).json)
     to_w.flush
     Oj.strict_load(from_r, symbol_keys: true) { |msg| reply = msg; break }
   }

--- a/test/test_io_shell.rb
+++ b/test/test_io_shell.rb
@@ -155,7 +155,7 @@ class TestIoShell < Minitest::Test
       # desired.
       script.each { |pair|
         unless pair[0].nil?
-          to_w.puts(WAB::Impl::Data.new(pair[0], false).json)
+          to_w.puts(WAB::Impl::Data.new(pair[0]).json)
           to_w.flush
         end
 
@@ -179,7 +179,7 @@ class TestIoShell < Minitest::Test
       # fail. Thats okay as the write is only to tell the child to shutdown
       # and it already has.
       begin
-        to_w.puts(WAB::Impl::Data.new({ api: -2 }, false).json)
+        to_w.puts(WAB::Impl::Data.new({ api: -2 }).json)
         to_w.flush
       rescue Exception
       end


### PR DESCRIPTION
Since the majority of `Impl::Data` instances seem to have been initialized with `false` passed as an argument,  I think we can simplify by having the `repair` parameter for `Impl::Data.new` set to `false` by default.

This *doesn't* change the class API so everything should work same as before